### PR TITLE
add group management roles

### DIFF
--- a/keycloak-dev/realms/moh_applications/user-management-service/main.tf
+++ b/keycloak-dev/realms/moh_applications/user-management-service/main.tf
@@ -37,6 +37,12 @@ module "client-roles" {
     "manage-user-groups" = {
       "name" = "manage-user-groups"
     },
+    "manage-all-groups" = {
+      "name" = "manage-all-groups"
+    },
+    "manage-own-groups" = {
+      "name" = "manage-own-groups"
+    },
     "manage-user-roles" = {
       "name" = "manage-user-roles"
     },
@@ -194,6 +200,10 @@ module "service-account-roles" {
     "USER-MANAGEMENT-SERVICE/manage-user-groups" = {
       "client_id" = keycloak_openid_client.CLIENT.id,
       "role_id"   = "manage-user-groups"
+    }
+    "USER-MANAGEMENT-SERVICE/manage-all-groups" = {
+      "client_id" = keycloak_openid_client.CLIENT.id,
+      "role_id"   = "manage-all-groups"
     }
     "USER-MANAGEMENT-SERVICE/manage-user-roles" = {
       "client_id" = keycloak_openid_client.CLIENT.id,

--- a/keycloak-dev/realms/moh_applications/user-management/main.tf
+++ b/keycloak-dev/realms/moh_applications/user-management/main.tf
@@ -38,6 +38,14 @@ module "client-roles" {
     },
   }
 }
+resource "keycloak_openid_group_membership_protocol_mapper" "Group-Membership" {
+  name             = "user groups"
+  claim_name       = "groups"
+  client_id        = keycloak_openid_client.CLIENT.id
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  add_to_userinfo  = false
+  add_to_id_token  = false
+}
 module "scope-mappings" {
   source    = "../../../../modules/scope-mappings"
   realm_id  = keycloak_openid_client.CLIENT.realm_id
@@ -46,6 +54,8 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/create-user"                           = var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-details"                   = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-groups"                    = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-groups"].id,
+    "USER-MANAGEMENT-SERVICE/manage-all-groups"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-all-groups"].id,
+    "USER-MANAGEMENT-SERVICE/manage-own-groups"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-roles"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     "USER-MANAGEMENT-SERVICE/view-client-bcer-cp"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
     "USER-MANAGEMENT-SERVICE/view-client-eacl"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl"].id,

--- a/keycloak-dev/realms/moh_applications/user-management/main.tf
+++ b/keycloak-dev/realms/moh_applications/user-management/main.tf
@@ -39,12 +39,12 @@ module "client-roles" {
   }
 }
 resource "keycloak_openid_group_membership_protocol_mapper" "Group-Membership" {
-  name             = "user groups"
-  claim_name       = "groups"
-  client_id        = keycloak_openid_client.CLIENT.id
-  realm_id         = keycloak_openid_client.CLIENT.realm_id
-  add_to_userinfo  = false
-  add_to_id_token  = false
+  name            = "user groups"
+  claim_name      = "groups"
+  client_id       = keycloak_openid_client.CLIENT.id
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  add_to_userinfo = false
+  add_to_id_token = false
 }
 module "scope-mappings" {
   source    = "../../../../modules/scope-mappings"

--- a/keycloak-prod/realms/moh_applications/user-management-service/main.tf
+++ b/keycloak-prod/realms/moh_applications/user-management-service/main.tf
@@ -37,6 +37,12 @@ module "client-roles" {
     "manage-user-groups" = {
       "name" = "manage-user-groups"
     },
+    "manage-all-groups" = {
+      "name" = "manage-all-groups"
+    },
+    "manage-own-groups" = {
+      "name" = "manage-own-groups"
+    },
     "manage-user-roles" = {
       "name" = "manage-user-roles"
     },
@@ -182,6 +188,10 @@ module "service-account-roles" {
     "USER-MANAGEMENT-SERVICE/manage-user-groups" = {
       "client_id" = keycloak_openid_client.CLIENT.id,
       "role_id"   = "manage-user-groups"
+    }
+    "USER-MANAGEMENT-SERVICE/manage-all-groups" = {
+      "client_id" = keycloak_openid_client.CLIENT.id,
+      "role_id"   = "manage-all-groups"
     }
     "USER-MANAGEMENT-SERVICE/manage-user-roles" = {
       "client_id" = keycloak_openid_client.CLIENT.id,

--- a/keycloak-prod/realms/moh_applications/user-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/user-management/main.tf
@@ -37,12 +37,12 @@ module "client-roles" {
   }
 }
 resource "keycloak_openid_group_membership_protocol_mapper" "Group-Membership" {
-  name             = "user groups"
-  claim_name       = "groups"
-  client_id        = keycloak_openid_client.CLIENT.id
-  realm_id         = keycloak_openid_client.CLIENT.realm_id
-  add_to_userinfo  = false
-  add_to_id_token  = false
+  name            = "user groups"
+  claim_name      = "groups"
+  client_id       = keycloak_openid_client.CLIENT.id
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  add_to_userinfo = false
+  add_to_id_token = false
 }
 module "scope-mappings" {
   source    = "../../../../modules/scope-mappings"

--- a/keycloak-prod/realms/moh_applications/user-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/user-management/main.tf
@@ -36,6 +36,14 @@ module "client-roles" {
     },
   }
 }
+resource "keycloak_openid_group_membership_protocol_mapper" "Group-Membership" {
+  name             = "user groups"
+  claim_name       = "groups"
+  client_id        = keycloak_openid_client.CLIENT.id
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  add_to_userinfo  = false
+  add_to_id_token  = false
+}
 module "scope-mappings" {
   source    = "../../../../modules/scope-mappings"
   realm_id  = keycloak_openid_client.CLIENT.realm_id
@@ -44,6 +52,8 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/create-user"                           = var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-details"                   = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-groups"                    = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-groups"].id,
+    "USER-MANAGEMENT-SERVICE/manage-all-groups"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-all-groups"].id,
+    "USER-MANAGEMENT-SERVICE/manage-own-groups"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-roles"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     "USER-MANAGEMENT-SERVICE/view-client-bcer-cp"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
     "USER-MANAGEMENT-SERVICE/view-client-eacl"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl"].id,

--- a/keycloak-test/realms/moh_applications/user-management-service/main.tf
+++ b/keycloak-test/realms/moh_applications/user-management-service/main.tf
@@ -37,6 +37,12 @@ module "client-roles" {
     "manage-user-groups" = {
       "name" = "manage-user-groups"
     },
+    "manage-all-groups" = {
+      "name" = "manage-all-groups"
+    },
+    "manage-own-groups" = {
+      "name" = "manage-own-groups"
+    },
     "manage-user-roles" = {
       "name" = "manage-user-roles"
     },
@@ -230,6 +236,10 @@ module "service-account-roles" {
     "USER-MANAGEMENT-SERVICE/manage-user-groups" = {
       "client_id" = keycloak_openid_client.CLIENT.id,
       "role_id"   = "manage-user-groups"
+    }
+    "USER-MANAGEMENT-SERVICE/manage-all-groups" = {
+      "client_id" = keycloak_openid_client.CLIENT.id,
+      "role_id"   = "manage-all-groups"
     }
     "USER-MANAGEMENT-SERVICE/manage-user-roles" = {
       "client_id" = keycloak_openid_client.CLIENT.id,

--- a/keycloak-test/realms/moh_applications/user-management/main.tf
+++ b/keycloak-test/realms/moh_applications/user-management/main.tf
@@ -37,12 +37,12 @@ module "client-roles" {
   }
 }
 resource "keycloak_openid_group_membership_protocol_mapper" "Group-Membership" {
-  name             = "user groups"
-  claim_name       = "groups"
-  client_id        = keycloak_openid_client.CLIENT.id
-  realm_id         = keycloak_openid_client.CLIENT.realm_id
-  add_to_userinfo  = false
-  add_to_id_token  = false
+  name            = "user groups"
+  claim_name      = "groups"
+  client_id       = keycloak_openid_client.CLIENT.id
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  add_to_userinfo = false
+  add_to_id_token = false
 }
 module "scope-mappings" {
   source    = "../../../../modules/scope-mappings"

--- a/keycloak-test/realms/moh_applications/user-management/main.tf
+++ b/keycloak-test/realms/moh_applications/user-management/main.tf
@@ -36,6 +36,14 @@ module "client-roles" {
     },
   }
 }
+resource "keycloak_openid_group_membership_protocol_mapper" "Group-Membership" {
+  name             = "user groups"
+  claim_name       = "groups"
+  client_id        = keycloak_openid_client.CLIENT.id
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  add_to_userinfo  = false
+  add_to_id_token  = false
+}
 module "scope-mappings" {
   source    = "../../../../modules/scope-mappings"
   realm_id  = keycloak_openid_client.CLIENT.realm_id
@@ -44,6 +52,8 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/create-user"                           = var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-details"                   = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-groups"                    = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-groups"].id,
+    "USER-MANAGEMENT-SERVICE/manage-all-groups"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-all-groups"].id,
+    "USER-MANAGEMENT-SERVICE/manage-own-groups"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-roles"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     "USER-MANAGEMENT-SERVICE/view-client-bcer-cp"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
     "USER-MANAGEMENT-SERVICE/view-client-eacl"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl"].id,


### PR DESCRIPTION
two new roles: 

- manage-own-groups
- manage-all-groups

USER_MANAGEMENT mapper: groups are now shown in access token

manage-user-groups will be deprecated - I will delete it after code review