### PR TITLE
Add new role to SAT-EFORMS client in DEV and TEST.

### DIFF
--- a/keycloak-dev/realms/moh_applications/sat-eforms/main.tf
+++ b/keycloak-dev/realms/moh_applications/sat-eforms/main.tf
@@ -33,6 +33,9 @@ module "client-roles" {
     "phsa_eforms_sat" = {
       "name" = "phsa_eforms_sat"
     },
+    "phsa_eforms_sat2" = {
+      "name" = "phsa_eforms_sat2"
+    }
   }
 }
 resource "keycloak_openid_user_attribute_protocol_mapper" "bcsc_id" {

--- a/keycloak-test/realms/moh_applications/sat-eforms/main.tf
+++ b/keycloak-test/realms/moh_applications/sat-eforms/main.tf
@@ -33,6 +33,9 @@ module "client-roles" {
     "phsa_eforms_sat" = {
       "name" = "phsa_eforms_sat"
     },
+    "phsa_eforms_sat2" = {
+      "name" = "phsa_eforms_sat2"
+    }
   }
 }
 resource "keycloak_openid_user_attribute_protocol_mapper" "bcsc_id" {


### PR DESCRIPTION
Requested by James Hollinger of the PIDP team.

The PIPD team requested this new role because they want to "enrol" users in it. The PIDP client already has the required scope client role mapping for "view-client-sat-eforms", so it doesn't need to be updated with a new role.