### PR TITLE
Organizations API DEV and TEST change. Disable standard flow, which c…

### DIFF
--- a/keycloak-dev/realms/moh_applications/organizations-api/main.tf
+++ b/keycloak-dev/realms/moh_applications/organizations-api/main.tf
@@ -16,7 +16,7 @@ resource "keycloak_openid_client" "CLIENT" {
   pkce_code_challenge_method          = ""
   realm_id                            = "moh_applications"
   service_accounts_enabled            = false
-  standard_flow_enabled               = true
+  standard_flow_enabled               = false
   valid_redirect_uris = [
   ]
   web_origins = [

--- a/keycloak-test/realms/moh_applications/organizations-api/main.tf
+++ b/keycloak-test/realms/moh_applications/organizations-api/main.tf
@@ -16,7 +16,7 @@ resource "keycloak_openid_client" "CLIENT" {
   pkce_code_challenge_method          = ""
   realm_id                            = "moh_applications"
   service_accounts_enabled            = false
-  standard_flow_enabled               = true
+  standard_flow_enabled               = false
   valid_redirect_uris = [
   ]
   web_origins = [


### PR DESCRIPTION
…auses a Terraform apply error since bearer-only clients cannot have flows enabled.