### PR TITLE
PIDP-SERVICE service account to manage DMFT-SERVICE roles

### DIFF
--- a/keycloak-dev/realms/moh_applications/dmft-service/main.tf
+++ b/keycloak-dev/realms/moh_applications/dmft-service/main.tf
@@ -4,7 +4,7 @@ resource "keycloak_openid_client" "CLIENT" {
   backchannel_logout_session_required = true
   base_url                            = ""
   client_authenticator_type           = "client-secret"
-  client_id                           = "DMFT-SERVICE-ACCOUNT"
+  client_id                           = "DMFT-SERVICE"
   consent_required                    = false
   description                         = "Driver Medical Fitness Transformation"
   direct_access_grants_enabled        = false

--- a/keycloak-dev/realms/moh_applications/pidp-service/main.tf
+++ b/keycloak-dev/realms/moh_applications/pidp-service/main.tf
@@ -80,6 +80,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/create-user"              = var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-details"      = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-roles"        = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-hcimweb"      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-dmft-service"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hcimweb"      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb"].id,
     "USER-MANAGEMENT-SERVICE/view-client-pidp-service" = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pidp-service"].id,
     "USER-MANAGEMENT-SERVICE/view-client-sat-eforms"   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sat-eforms"].id,
@@ -108,6 +109,10 @@ module "service-account-roles" {
     "USER-MANAGEMENT-SERVICE/manage-user-roles" = {
       "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
       "role_id"   = "manage-user-roles"
+    }
+    "USER-MANAGEMENT-SERVICE/view-client-dmft-service" = {
+      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
+      "role_id"   = "view-client-dmft-service"
     }
     "USER-MANAGEMENT-SERVICE/view-client-hcimweb" = {
       "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,

--- a/keycloak-dev/realms/moh_applications/user-management-service/main.tf
+++ b/keycloak-dev/realms/moh_applications/user-management-service/main.tf
@@ -46,6 +46,9 @@ module "client-roles" {
     "view-client-bcer-cp" = {
       "name" = "view-client-bcer-cp"
     },
+    "view-client-dmft-service" = {
+      "name" = "view-client-dmft-service"
+    },
     "view-client-eacl" = {
       "name" = "view-client-eacl"
     },


### PR DESCRIPTION
Give the PIDP-SERVICE service account permission to manage DMFT-SERVI…CE roles. Also rename the DMFT-SERVICE-ACCOUNT client to simply DMFT-SERVICE to be consistent with other clients.