### PR TITLE
remove sat-case sat-drug roles and scope mappings

### DIFF
--- a/keycloak-dev/realms/moh_applications/user-management-service/main.tf
+++ b/keycloak-dev/realms/moh_applications/user-management-service/main.tf
@@ -106,12 +106,6 @@ module "client-roles" {
     "view-client-sa-sfdc" = {
       "name" = "view-client-sa-sfdc"
     },
-    "view-client-sat-case-management-1" = {
-      "name" = "view-client-sat-case-management-1"
-    },
-    "view-client-sat-drug-management-1" = {
-      "name" = "view-client-sat-drug-management-1"
-    },
     "view-client-sat-eforms" = {
       "name" = "view-client-sat-eforms"
     },
@@ -291,14 +285,6 @@ module "service-account-roles" {
     "USER-MANAGEMENT-SERVICE/view-client-sa-sfdc" = {
       "client_id" = keycloak_openid_client.CLIENT.id,
       "role_id"   = "view-client-sa-sfdc"
-    }
-    "USER-MANAGEMENT-SERVICE/view-client-sat-case-management-1" = {
-      "client_id" = keycloak_openid_client.CLIENT.id,
-      "role_id"   = "view-client-sat-case-management-1"
-    }
-    "USER-MANAGEMENT-SERVICE/view-client-sat-drug-management-1" = {
-      "client_id" = keycloak_openid_client.CLIENT.id,
-      "role_id"   = "view-client-sat-drug-management-1"
     }
     "USER-MANAGEMENT-SERVICE/view-client-sat-eforms" = {
       "client_id" = keycloak_openid_client.CLIENT.id,

--- a/keycloak-dev/realms/moh_applications/user-management/main.tf
+++ b/keycloak-dev/realms/moh_applications/user-management/main.tf
@@ -79,8 +79,6 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-client-sa-dbaac-portal"           = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-dbaac-portal"].id,
     "USER-MANAGEMENT-SERVICE/view-client-sa-hibc-service-bc-portal" = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-hibc-service-bc-portal"].id,
     "USER-MANAGEMENT-SERVICE/view-client-sa-sfdc"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-sfdc"].id,
-    "USER-MANAGEMENT-SERVICE/view-client-sat-case-management-1"     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sat-case-management-1"].id,
-    "USER-MANAGEMENT-SERVICE/view-client-sat-drug-management-1"     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sat-drug-management-1"].id,
     "USER-MANAGEMENT-SERVICE/view-client-sat-eforms"                = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sat-eforms"].id,
     "USER-MANAGEMENT-SERVICE/view-client-sfds"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sfds"].id,
     "USER-MANAGEMENT-SERVICE/view-client-swt"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-swt"].id,


### PR DESCRIPTION
SAT-DRUG-MANAGEMENT-1 and SAT-CASE-MANAGEMENT-1 deleted from DEV manually

manually deleted scope mappings and removed them from tf.state file, not to trigger the scope-mapping deletion bug.
Manually removed two corresponding UMS roles from tf.state file