### PR TITLE
Add HCAP service account to manage HCAP roles via UMS

### DIFF
--- a/keycloak-test/realms/moh_applications/hcap-service/main.tf
+++ b/keycloak-test/realms/moh_applications/hcap-service/main.tf
@@ -1,4 +1,4 @@
- resource "keycloak_openid_client" "CLIENT" {
+resource "keycloak_openid_client" "CLIENT" {
   access_token_lifespan               = "300"
   access_type                         = "CONFIDENTIAL"
   backchannel_logout_session_required = true

--- a/keycloak-test/realms/moh_applications/hcap-service/main.tf
+++ b/keycloak-test/realms/moh_applications/hcap-service/main.tf
@@ -38,7 +38,6 @@ module "service-account-roles" {
   source    = "../../../../modules/service-account-roles"
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
-  //noinspection HILUnresolvedReference
   service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
   realm_roles = {
     "default-roles-moh_applications" = "default-roles-moh_applications",

--- a/keycloak-test/realms/moh_applications/hcap-service/main.tf
+++ b/keycloak-test/realms/moh_applications/hcap-service/main.tf
@@ -1,0 +1,64 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = "300"
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "HCAP-SERVICE"
+  consent_required                    = false
+  description                         = "A service account to manage HCAP roles using UMS."
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = ""
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = true
+  standard_flow_enabled               = false
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+
+module "scope-mappings" {
+  source    = "../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "USER-MANAGEMENT-SERVICE/manage-user-roles"             = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+#    "USER-MANAGEMENT-SERVICE/view-client-mspdirect-service" = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-mspdirect-service"].id,
+    "USER-MANAGEMENT-SERVICE/view-clients"                  = var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    "USER-MANAGEMENT-SERVICE/view-users"                    = var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
+  }
+}
+module "service-account-roles" {
+  source                  = "../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  //noinspection HILUnresolvedReference
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {
+    "USER-MANAGEMENT-SERVICE/manage-user-roles" = {
+      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
+      "role_id"   = "manage-user-roles"
+    }
+#    "USER-MANAGEMENT-SERVICE/view-client-mspdirect-service" = {
+#      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
+#      "role_id"   = "view-client-mspdirect-service"
+#    }
+    "USER-MANAGEMENT-SERVICE/view-clients" = {
+      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
+      "role_id"   = "view-clients"
+    }
+    "USER-MANAGEMENT-SERVICE/view-users" = {
+      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
+      "role_id"   = "view-users"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/hcap-service/main.tf
+++ b/keycloak-test/realms/moh_applications/hcap-service/main.tf
@@ -35,9 +35,9 @@ module "scope-mappings" {
   }
 }
 module "service-account-roles" {
-  source    = "../../../../modules/service-account-roles"
-  realm_id  = keycloak_openid_client.CLIENT.realm_id
-  client_id = keycloak_openid_client.CLIENT.id
+  source                  = "../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
   service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
   realm_roles = {
     "default-roles-moh_applications" = "default-roles-moh_applications",

--- a/keycloak-test/realms/moh_applications/hcap-service/main.tf
+++ b/keycloak-test/realms/moh_applications/hcap-service/main.tf
@@ -1,4 +1,4 @@
-resource "keycloak_openid_client" "CLIENT" {
+ resource "keycloak_openid_client" "CLIENT" {
   access_token_lifespan               = "300"
   access_type                         = "CONFIDENTIAL"
   backchannel_logout_session_required = true
@@ -28,16 +28,16 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "USER-MANAGEMENT-SERVICE/manage-user-roles"             = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
-#    "USER-MANAGEMENT-SERVICE/view-client-mspdirect-service" = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-mspdirect-service"].id,
-    "USER-MANAGEMENT-SERVICE/view-clients"                  = var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
-    "USER-MANAGEMENT-SERVICE/view-users"                    = var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
+    "USER-MANAGEMENT-SERVICE/manage-user-roles" = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    #    "USER-MANAGEMENT-SERVICE/view-client-mspdirect-service" = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-mspdirect-service"].id,
+    "USER-MANAGEMENT-SERVICE/view-clients" = var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    "USER-MANAGEMENT-SERVICE/view-users"   = var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
   }
 }
 module "service-account-roles" {
-  source                  = "../../../../modules/service-account-roles"
-  realm_id                = keycloak_openid_client.CLIENT.realm_id
-  client_id               = keycloak_openid_client.CLIENT.id
+  source    = "../../../../modules/service-account-roles"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
   //noinspection HILUnresolvedReference
   service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
   realm_roles = {
@@ -48,10 +48,10 @@ module "service-account-roles" {
       "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
       "role_id"   = "manage-user-roles"
     }
-#    "USER-MANAGEMENT-SERVICE/view-client-mspdirect-service" = {
-#      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-#      "role_id"   = "view-client-mspdirect-service"
-#    }
+    #    "USER-MANAGEMENT-SERVICE/view-client-mspdirect-service" = {
+    #      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
+    #      "role_id"   = "view-client-mspdirect-service"
+    #    }
     "USER-MANAGEMENT-SERVICE/view-clients" = {
       "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
       "role_id"   = "view-clients"

--- a/keycloak-test/realms/moh_applications/hcap-service/outputs.tf
+++ b/keycloak-test/realms/moh_applications/hcap-service/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/hcap-service/variables.tf
+++ b/keycloak-test/realms/moh_applications/hcap-service/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/hcap-service/versions.tf
+++ b/keycloak-test/realms/moh_applications/hcap-service/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = ">= 3.0.0"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/main.tf
+++ b/keycloak-test/realms/moh_applications/main.tf
@@ -26,6 +26,11 @@ module "HAMIS" {
   source                  = "./hamis"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
 }
+module "HCAP-SERVICE" {
+  source                  = "./hcap-service"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
 module "HCIMWEB_HIAT1" {
   source = "./hcimweb_hiat1"
 }


### PR DESCRIPTION
Add HCAP service account to manage HCAP roles via UMS. Will add stub HCAP client in another PR.