### PR TITLE
Add a 'name' to the HSIAR client. 

### DIFF
--- a/keycloak-test/realms/moh_applications/hsiar/main.tf
+++ b/keycloak-test/realms/moh_applications/hsiar/main.tf
@@ -12,7 +12,7 @@ resource "keycloak_openid_client" "CLIENT" {
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
   implicit_flow_enabled               = false
-  name                                = ""
+  name                                = "HSIAR"
   pkce_code_challenge_method          = ""
   realm_id                            = "moh_applications"
   service_accounts_enabled            = false


### PR DESCRIPTION
Our login template requires a name or else an internal Keycloak exception is produced when you attempt to login.