### PR TITLE
Remove remove the feature_amh_demo role 

### DIFF
--- a/keycloak-dev/realms/moh_applications/pidp-service/main.tf
+++ b/keycloak-dev/realms/moh_applications/pidp-service/main.tf
@@ -34,9 +34,6 @@ module "client-roles" {
     "USER" = {
       "name" = "USER"
     },
-    "feature_amh_demo" = {
-      "name" = "feature_amh_demo"
-    },
     "feature_pidp_demo" = {
       "name" = "feature_pidp_demo"
     },

--- a/keycloak-dev/realms/moh_applications/pidp-webapp/main.tf
+++ b/keycloak-dev/realms/moh_applications/pidp-webapp/main.tf
@@ -171,7 +171,6 @@ module "scope-mappings" {
   roles = {
     "PIDP-SERVICE/ADMIN"             = var.PIDP-SERVICE.ROLES["ADMIN"].id,
     "PIDP-SERVICE/USER"              = var.PIDP-SERVICE.ROLES["USER"].id,
-    "PIDP-SERVICE/feature_amh_demo"  = var.PIDP-SERVICE.ROLES["feature_amh_demo"].id,
     "PIDP-SERVICE/feature_pidp_demo" = var.PIDP-SERVICE.ROLES["feature_pidp_demo"].id,
     "account/view-profile"           = var.account.ROLES["view-profile"].id,
   }

--- a/keycloak-test/realms/moh_applications/pidp-service/main.tf
+++ b/keycloak-test/realms/moh_applications/pidp-service/main.tf
@@ -34,9 +34,6 @@ module "client-roles" {
     "USER" = {
       "name" = "USER"
     },
-    "feature_amh_demo" = {
-      "name" = "feature_amh_demo"
-    },
     "feature_pidp_demo" = {
       "name" = "feature_pidp_demo"
     },

--- a/keycloak-test/realms/moh_applications/pidp-webapp/main.tf
+++ b/keycloak-test/realms/moh_applications/pidp-webapp/main.tf
@@ -63,7 +63,6 @@ module "scope-mappings" {
   roles = {
     "PIDP-SERVICE/ADMIN"             = var.PIDP-SERVICE.ROLES["ADMIN"].id,
     "PIDP-SERVICE/USER"              = var.PIDP-SERVICE.ROLES["USER"].id,
-    "PIDP-SERVICE/feature_amh_demo"  = var.PIDP-SERVICE.ROLES["feature_amh_demo"].id,
     "PIDP-SERVICE/feature_pidp_demo" = var.PIDP-SERVICE.ROLES["feature_pidp_demo"].id,
     "account/view-profile"           = var.account.ROLES["view-profile"].id,
   }


### PR DESCRIPTION
Remove remove the feature_amh_demo role from PIDP-SERVICE at the request of James Hollinger.

### Will need to re-run `apply` after merge to restore missing scopes due to Keycloak provider bug!

After this PR, I will submit one for PROD.