### PR TITLE
remove pidp role from prod

### DIFF
--- a/keycloak-prod/realms/moh_applications/pidp-service/main.tf
+++ b/keycloak-prod/realms/moh_applications/pidp-service/main.tf
@@ -34,9 +34,6 @@ module "client-roles" {
     "USER" = {
       "name" = "USER"
     },
-    "feature_amh_demo" = {
-      "name" = "feature_amh_demo"
-    },
     "feature_pidp_demo" = {
       "name" = "feature_pidp_demo"
     },

--- a/keycloak-prod/realms/moh_applications/pidp-webapp/main.tf
+++ b/keycloak-prod/realms/moh_applications/pidp-webapp/main.tf
@@ -49,7 +49,6 @@ module "scope-mappings" {
   roles = {
     "PIDP-SERVICE/ADMIN"             = var.PIDP-SERVICE.ROLES["ADMIN"].id,
     "PIDP-SERVICE/USER"              = var.PIDP-SERVICE.ROLES["USER"].id,
-    "PIDP-SERVICE/feature_amh_demo"  = var.PIDP-SERVICE.ROLES["feature_amh_demo"].id,
     "PIDP-SERVICE/feature_pidp_demo" = var.PIDP-SERVICE.ROLES["feature_pidp_demo"].id,
     "account/view-profile"           = var.account.ROLES["view-profile"].id,
   }


### PR DESCRIPTION
need to re-run the apply command to recreate deleted scope mappings