### PR TITLE
allow prime-test in umc and import service account test roles

### DIFF
--- a/keycloak-test/realms/moh_applications/main.tf
+++ b/keycloak-test/realms/moh_applications/main.tf
@@ -261,15 +261,22 @@ module "PRIME-APPLICATION-TEST" {
   source = "./prime-application-test"
 }
 module "PRIME-APPLICATION-SERVICE-ACCOUNT" {
-  source = "./prime-application-service-account"
+  source                  = "./prime-application-service-account"
+  PRIME-APPLICATION-LOCAL = module.PRIME-APPLICATION-LOCAL
+  PRIME-APPLICATION-TEST  = module.PRIME-APPLICATION-TEST
+
 }
 module "PRIME-MEDINET-ACCESS" {
   source                  = "./prime-medinet-access"
   PRIME-APPLICATION-LOCAL = module.PRIME-APPLICATION-LOCAL
+  PRIME-APPLICATION-TEST  = module.PRIME-APPLICATION-TEST
+
 }
 module "PRIME-CARECONNECT-ACCESS" {
   source                  = "./prime-careconnect-access"
   PRIME-APPLICATION-LOCAL = module.PRIME-APPLICATION-LOCAL
+  PRIME-APPLICATION-TEST  = module.PRIME-APPLICATION-TEST
+
 }
 module "PRIME-WEBAPP-ENROLLMENT" {
   source  = "./prime-webapp-enrollment"

--- a/keycloak-test/realms/moh_applications/prime-application-local/main.tf
+++ b/keycloak-test/realms/moh_applications/prime-application-local/main.tf
@@ -108,5 +108,8 @@ module "client-roles" {
     "external_hpdid_access" = {
       "name" = "external_hpdid_access"
     },
+    "prime_api_service_account" = {
+      "name" = "prime_api_service_account"
+    },
   }
 }

--- a/keycloak-test/realms/moh_applications/prime-application-service-account/main.tf
+++ b/keycloak-test/realms/moh_applications/prime-application-service-account/main.tf
@@ -31,3 +31,33 @@ resource "keycloak_openid_audience_protocol_mapper" "Prime-Audience-Mapper" {
   name                     = "Prime Audience Mapper"
   realm_id                 = keycloak_openid_client.CLIENT.realm_id
 }
+
+module "service-account-roles" {
+  source                  = "../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {
+    "PRIME-APPLICATION-LOCAL/prime_api_service_account" = {
+      "client_id" = var.PRIME-APPLICATION-LOCAL.CLIENT.id,
+      "role_id"   = "prime_api_service_account"
+    }
+    "PRIME-APPLICATION-TEST/prime_api_service_account" = {
+      "client_id" = var.PRIME-APPLICATION-TEST.CLIENT.id,
+      "role_id"   = "prime_api_service_account"
+    }
+  }
+}
+
+module "scope-mappings" {
+  source    = "../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "PRIME-APPLICATION-LOCAL/prime_api_service_account" = var.PRIME-APPLICATION-LOCAL.ROLES["prime_api_service_account"].id,
+    "PRIME-APPLICATION-TEST/prime_api_service_account"  = var.PRIME-APPLICATION-TEST.ROLES["prime_api_service_account"].id
+  }
+}

--- a/keycloak-test/realms/moh_applications/prime-application-service-account/variables.tf
+++ b/keycloak-test/realms/moh_applications/prime-application-service-account/variables.tf
@@ -1,0 +1,2 @@
+variable "PRIME-APPLICATION-LOCAL" {}
+variable "PRIME-APPLICATION-TEST" {}

--- a/keycloak-test/realms/moh_applications/prime-application-test/main.tf
+++ b/keycloak-test/realms/moh_applications/prime-application-test/main.tf
@@ -108,5 +108,8 @@ module "client-roles" {
     "external_hpdid_access" = {
       "name" = "external_hpdid_access"
     },
+    "prime_api_service_account" = {
+      "name" = "prime_api_service_account"
+    },
   }
 }

--- a/keycloak-test/realms/moh_applications/prime-careconnect-access/main.tf
+++ b/keycloak-test/realms/moh_applications/prime-careconnect-access/main.tf
@@ -44,6 +44,10 @@ module "service-account-roles" {
     "PRIME-APPLICATION-LOCAL/external_hpdid_access" = {
       "client_id" = var.PRIME-APPLICATION-LOCAL.CLIENT.id,
       "role_id"   = "external_hpdid_access"
+    },
+    "PRIME-APPLICATION-TEST/external_hpdid_access" = {
+      "client_id" = var.PRIME-APPLICATION-TEST.CLIENT.id,
+      "role_id"   = "external_hpdid_access"
     }
   }
 }
@@ -53,6 +57,7 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "PRIME-APPLICATION-LOCAL/external_hpdid_access" = var.PRIME-APPLICATION-LOCAL.ROLES["external_hpdid_access"].id
+    "PRIME-APPLICATION-LOCAL/external_hpdid_access" = var.PRIME-APPLICATION-LOCAL.ROLES["external_hpdid_access"].id,
+    "PRIME-APPLICATION-TEST/external_hpdid_access"  = var.PRIME-APPLICATION-TEST.ROLES["external_hpdid_access"].id
   }
 }

--- a/keycloak-test/realms/moh_applications/prime-careconnect-access/variables.tf
+++ b/keycloak-test/realms/moh_applications/prime-careconnect-access/variables.tf
@@ -1,1 +1,2 @@
 variable "PRIME-APPLICATION-LOCAL" {}
+variable "PRIME-APPLICATION-TEST" {}

--- a/keycloak-test/realms/moh_applications/prime-medinet-access/main.tf
+++ b/keycloak-test/realms/moh_applications/prime-medinet-access/main.tf
@@ -44,6 +44,10 @@ module "service-account-roles" {
     "PRIME-APPLICATION-LOCAL/external_gpid_validation" = {
       "client_id" = var.PRIME-APPLICATION-LOCAL.CLIENT.id,
       "role_id"   = "external_gpid_validation"
+    },
+    "PRIME-APPLICATION-TEST/external_gpid_validation" = {
+      "client_id" = var.PRIME-APPLICATION-TEST.CLIENT.id,
+      "role_id"   = "external_gpid_validation"
     }
   }
 }
@@ -54,5 +58,6 @@ module "scope-mappings" {
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
     "PRIME-APPLICATION-LOCAL/external_gpid_validation" = var.PRIME-APPLICATION-LOCAL.ROLES["external_gpid_validation"].id
+    "PRIME-APPLICATION-TEST/external_gpid_validation"  = var.PRIME-APPLICATION-TEST.ROLES["external_gpid_validation"].id
   }
 }

--- a/keycloak-test/realms/moh_applications/prime-medinet-access/variables.tf
+++ b/keycloak-test/realms/moh_applications/prime-medinet-access/variables.tf
@@ -1,1 +1,2 @@
 variable "PRIME-APPLICATION-LOCAL" {}
+variable "PRIME-APPLICATION-TEST" {}

--- a/keycloak-test/realms/moh_applications/user-management-service/main.tf
+++ b/keycloak-test/realms/moh_applications/user-management-service/main.tf
@@ -148,6 +148,9 @@ module "client-roles" {
     "view-client-prime-application-local" = {
       "name" = "view-client-prime-application-local"
     },
+    "view-client-prime-application-test" = {
+      "name" = "view-client-prime-application-test"
+    },
     "view-client-prp-service" = {
       "name" = "view-client-prp-service"
     },

--- a/keycloak-test/realms/moh_applications/user-management/main.tf
+++ b/keycloak-test/realms/moh_applications/user-management/main.tf
@@ -89,6 +89,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-client-plr_uat"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_uat"].id,
     "USER-MANAGEMENT-SERVICE/view-client-primary-care"              = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-primary-care"].id,
     "USER-MANAGEMENT-SERVICE/view-client-prime-application-local"   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-prime-application-local"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-prime-application-test"    = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-prime-application-test"].id,
     "USER-MANAGEMENT-SERVICE/view-client-prp-service"               = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-prp-service"].id,
     "USER-MANAGEMENT-SERVICE/view-client-sa-dbaac-portal"           = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-dbaac-portal"].id,
     "USER-MANAGEMENT-SERVICE/view-client-sa-hibc-service-bc-portal" = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-hibc-service-bc-portal"].id,


### PR DESCRIPTION
Enable prime-application-test in UMC.
Import prime-application-service-account changes.
Import careconnect and medinet scope mappings and service account roles.