### PR TITLE
create WAVA client for PLR on test

### DIFF
--- a/keycloak-test/realms/moh_applications/main.tf
+++ b/keycloak-test/realms/moh_applications/main.tf
@@ -346,6 +346,16 @@ module "USER-MANAGEMENT" {
   source                  = "./user-management"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
 }
+module "WAVA" {
+  source   = "./plr-wava"
+  PLR_IAT  = module.PLR_IAT
+  PLR_UAT  = module.PLR_UAT
+  PLR_SIT  = module.PLR_SIT
+  PLR_CONF = module.PLR_CONF
+  PLR_REV  = module.PLR_REV
+  PLR_FLVR = module.PLR_FLVR
+  PLR_STG  = module.PLR_STG
+}
 module "WEBCAPS" {
   source = "./webcaps"
 }

--- a/keycloak-test/realms/moh_applications/plr-wava/main.tf
+++ b/keycloak-test/realms/moh_applications/plr-wava/main.tf
@@ -1,0 +1,78 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "Wava"
+  name                                = "Wava"
+  consent_required                    = false
+  description                         = "Service account allowing PLR to go through WAVA security scan."
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = true
+  standard_flow_enabled               = false
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+module "service-account-roles" {
+  source                  = "../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {
+    "PLR_IAT/SECONDARY_SOURCE" = {
+      "client_id" = var.PLR_IAT.CLIENT.id,
+      "role_id"   = "SECONDARY_SOURCE"
+    }
+    "PLR_UAT/SECONDARY_SOURCE" = {
+      "client_id" = var.PLR_UAT.CLIENT.id,
+      "role_id"   = "SECONDARY_SOURCE"
+    }
+    "PLR_CONF/SECONDARY_SOURCE" = {
+      "client_id" = var.PLR_CONF.CLIENT.id,
+      "role_id"   = "SECONDARY_SOURCE"
+    }
+    "PLR_SIT/SECONDARY_SOURCE" = {
+      "client_id" = var.PLR_SIT.CLIENT.id,
+      "role_id"   = "SECONDARY_SOURCE"
+    }
+    "PLR_REV/SECONDARY_SOURCE" = {
+      "client_id" = var.PLR_REV.CLIENT.id,
+      "role_id"   = "SECONDARY_SOURCE"
+    }
+    "PLR_STG/SECONDARY_SOURCE" = {
+      "client_id" = var.PLR_STG.CLIENT.id,
+      "role_id"   = "SECONDARY_SOURCE"
+    }
+    "PLR_FLVR/SECONDARY_SOURCE" = {
+      "client_id" = var.PLR_FLVR.CLIENT.id,
+      "role_id"   = "SECONDARY_SOURCE"
+    }
+  }
+}
+module "scope-mappings" {
+  source    = "../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "PLR_IAT/SECONDARY_SOURCE"  = var.PLR_IAT.ROLES["SECONDARY_SOURCE"].id
+    "PLR_UAT/SECONDARY_SOURCE"  = var.PLR_UAT.ROLES["SECONDARY_SOURCE"].id
+    "PLR_CONF/SECONDARY_SOURCE" = var.PLR_CONF.ROLES["SECONDARY_SOURCE"].id
+    "PLR_SIT/SECONDARY_SOURCE"  = var.PLR_SIT.ROLES["SECONDARY_SOURCE"].id
+    "PLR_REV/SECONDARY_SOURCE"  = var.PLR_REV.ROLES["SECONDARY_SOURCE"].id
+    "PLR_STG/SECONDARY_SOURCE"  = var.PLR_STG.ROLES["SECONDARY_SOURCE"].id
+    "PLR_FLVR/SECONDARY_SOURCE" = var.PLR_FLVR.ROLES["SECONDARY_SOURCE"].id
+  }
+}

--- a/keycloak-test/realms/moh_applications/plr-wava/outputs.tf
+++ b/keycloak-test/realms/moh_applications/plr-wava/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/plr-wava/variables.tf
+++ b/keycloak-test/realms/moh_applications/plr-wava/variables.tf
@@ -1,0 +1,7 @@
+variable "PLR_IAT" {}
+variable "PLR_UAT" {}
+variable "PLR_SIT" {}
+variable "PLR_CONF" {}
+variable "PLR_REV" {}
+variable "PLR_STG" {}
+variable "PLR_FLVR" {}

--- a/keycloak-test/realms/moh_applications/plr-wava/versions.tf
+++ b/keycloak-test/realms/moh_applications/plr-wava/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Creating `Wava` service account on TEST environment, with `secondary_source` role.

### Context

`PLR` is subject to Web Application Vulnerability Assessments. The client will allow to go through those scans.
 
### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Client module and all references are defined in main.tf in realm root folder.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.
