### PR TITLE
unassigne prime role, fix redirect uri, add role to ums dev for tests

### DIFF
--- a/keycloak-dev/realms/moh_applications/user-management-service/main.tf
+++ b/keycloak-dev/realms/moh_applications/user-management-service/main.tf
@@ -94,6 +94,9 @@ module "client-roles" {
     "view-client-pho-rsc" = {
       "name" = "view-client-pho-rsc"
     },
+    "view-client-user-management-service-integration-tests" = {
+      "name" = "view-client-user-management-service-integration-tests"
+    },
     "view-clients" = {
       "name" = "view-clients"
     },

--- a/keycloak-prod/realms/moh_applications/prime-careconnect-access/main.tf
+++ b/keycloak-prod/realms/moh_applications/prime-careconnect-access/main.tf
@@ -41,10 +41,6 @@ module "service-account-roles" {
     "default-roles-moh_applications" = "default-roles-moh_applications",
   }
   client_roles = {
-    "PRIME-APPLICATION/external_hpdid_access" = {
-      "client_id" = var.PRIME-APPLICATION.CLIENT.id,
-      "role_id"   = "external_hpdid_access"
-    },
   }
 }
 

--- a/keycloak-test/realms/moh_applications/dmft-webapp/main.tf
+++ b/keycloak-test/realms/moh_applications/dmft-webapp/main.tf
@@ -26,7 +26,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://portal-ui-0137d5-test.apps.silver.devops.gov.bc.ca/",
     "https://rsbc-dfp-medical-portal-dev.silver.devops.bcgov/api",
     "https://oauth.pstmn.io/v1/callback",
-    "https://medical-portal-pidp-0137d5-dev.apps.silver.devops.gov.bc.ca/",
+    "https://medical-portal-pidp-0137d5-dev.apps.silver.devops.gov.bc.ca/*",
   ]
   web_origins = [
     "*",


### PR DESCRIPTION
### Changes being made

1. Unassigned `external_hpdid_access` role from `PRIME-CARECONNECT-ACCESS` client on Prod env.
2. Fixed redirect URI for DMFT-WEBAPP on Test env.
3. Add view-client-* role to UMS on Dev env.

### Context

1. PRIME team wants to keep  `PRIME-CARECONNECT-ACCESS` client, but temporarily restrict access to their API.
2. `*` was missing at the end of URI. Changes won't be shown in terraform plan, as fix was already made manually.
3. `view-client-user-management-service-integration-tests` role is needed to run tests in UMS on a dedicated "test" client, instead of, for example `PLR` client. This will make sure, that test will still pass, in case `PLR` client moves to Test env, and gets deleted from Dev env.
 
### Quality Check

- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 