### PR TITLE
Update dmft roles and terraform permissions

### DIFF
--- a/keycloak-dev/realms/moh_applications/dmft-webapp/main.tf
+++ b/keycloak-dev/realms/moh_applications/dmft-webapp/main.tf
@@ -36,8 +36,8 @@ module "client-roles" {
   client_id = keycloak_openid_client.CLIENT.id
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   roles = {
-    "ROLE_NAME_TBD" = {
-      "name"        = "ROLE_NAME_TBD"
+    "DMFT_ENROLLED" = {
+      "name"        = "DMFT_ENROLLED"
       "description" = ""
     }
   }

--- a/keycloak-dev/realms/moh_applications/terraform/main.tf
+++ b/keycloak-dev/realms/moh_applications/terraform/main.tf
@@ -66,6 +66,7 @@ module "scope-mappings" {
     "realm-management/manage-users"   = var.realm-management.ROLES["manage-users"].id,
     "realm-management/query-users"    = var.realm-management.ROLES["query-users"].id,
     "realm-management/view-realm"     = var.realm-management.ROLES["view-realm"].id,
+    "realm-management/view-events"    = var.realm-management.ROLES["view-events"].id,
   }
 }
 
@@ -109,6 +110,10 @@ module "service-account-roles" {
     "realm-management/view-realm" = {
       "client_id" = var.realm-management.CLIENT.id,
       "role_id"   = "view-realm"
+    }
+    "realm-management/view-events" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "view-events"
     }
   }
 }

--- a/keycloak-dev/realms/moh_applications/ums-integration-tests/main.tf
+++ b/keycloak-dev/realms/moh_applications/ums-integration-tests/main.tf
@@ -33,6 +33,10 @@ module "client-roles" {
       "name"        = "TEST_ROLE"
       "description" = "Role used in UMS integration tests"
     },
+    "getUsersInRole_TEST_ROLE" = {
+      "name"        = "getUsersInRole_TEST_ROLE"
+      "description" = "role used for getUsersInRole test in UMS"
+    },
   }
 }
 

--- a/keycloak-prod/realms/moh_applications/dmft-webapp/main.tf
+++ b/keycloak-prod/realms/moh_applications/dmft-webapp/main.tf
@@ -35,8 +35,8 @@ module "client-roles" {
   client_id = keycloak_openid_client.CLIENT.id
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   roles = {
-    "ROLE_NAME_TBD" = {
-      "name"        = "ROLE_NAME_TBD"
+    "DMFT_ENROLLED" = {
+      "name"        = "DMFT_ENROLLED"
       "description" = ""
     }
   }

--- a/keycloak-prod/realms/moh_applications/terraform/main.tf
+++ b/keycloak-prod/realms/moh_applications/terraform/main.tf
@@ -36,6 +36,7 @@ module "scope-mappings" {
     "realm-management/manage-users"   = var.realm-management.ROLES["manage-users"].id,
     "realm-management/query-users"    = var.realm-management.ROLES["query-users"].id,
     "realm-management/view-realm"     = var.realm-management.ROLES["view-realm"].id,
+    "realm-management/view-events"    = var.realm-management.ROLES["view-events"].id,
   }
 }
 
@@ -79,6 +80,10 @@ module "service-account-roles" {
     "realm-management/view-realm" = {
       "client_id" = var.realm-management.CLIENT.id,
       "role_id"   = "view-realm"
+    }
+    "realm-management/view-events" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "view-events"
     }
   }
 }

--- a/keycloak-test/realms/moh_applications/dmft-webapp/main.tf
+++ b/keycloak-test/realms/moh_applications/dmft-webapp/main.tf
@@ -38,10 +38,6 @@ module "client-roles" {
   client_id = keycloak_openid_client.CLIENT.id
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   roles = {
-    "ROLE_NAME_TBD" = {
-      "name"        = "ROLE_NAME_TBD"
-      "description" = ""
-    },
     "DMFT_ENROLLED" = {
       "name"        = "DMFT_ENROLLED"
       "description" = ""

--- a/keycloak-test/realms/moh_applications/terraform/main.tf
+++ b/keycloak-test/realms/moh_applications/terraform/main.tf
@@ -36,6 +36,7 @@ module "scope-mappings" {
     "realm-management/manage-users"   = var.realm-management.ROLES["manage-users"].id,
     "realm-management/query-users"    = var.realm-management.ROLES["query-users"].id,
     "realm-management/view-realm"     = var.realm-management.ROLES["view-realm"].id,
+    "realm-management/view-events"    = var.realm-management.ROLES["view-events"].id,
   }
 }
 
@@ -79,6 +80,10 @@ module "service-account-roles" {
     "realm-management/view-realm" = {
       "client_id" = var.realm-management.CLIENT.id,
       "role_id"   = "view-realm"
+    }
+    "realm-management/view-events" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "view-events"
     }
   }
 }


### PR DESCRIPTION
### Changes being made

1. Update DMFT roles on all envs - add `DMFT_ENROLLED` role (previously added on test. Delete `ROLE_NAME_TBD`
2. Assign view-events role to terraform client on all envs.
3. Create role for UMS integration tests.

### Context

1. DMFT switches from `ROLE_NAME_TBD` to `DMFT_ENROLLED`.
2. In order to assign roles from `realm-management` client, `terraform` client needs to have those roles itself. In this case - `view-events` role is used by UMS and UMS-INTEGRATION-TESTS-ROLE and needs to be managed by terraform client.
3. `getUsersInRole_TEST_ROLE` is needed for tests to pass. It is permanently assigned to `umstest` user.
 
### Quality Check

- [ ] Client module and all references are defined in main.tf in realm root folder.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 
