### PR TITLE
Update Valid Redirect URIs for BCER Data Portal in Test

### DIFF
--- a/keycloak-test/realms/moh_applications/bcer-cp/main.tf
+++ b/keycloak-test/realms/moh_applications/bcer-cp/main.tf
@@ -23,8 +23,10 @@ resource "keycloak_openid_client" "CLIENT" {
     "http://localhost:3001/*",
     "https://localhost:3000/*",
     "https://localhost:3001/*",
+    "https://bcer-dev.hlth.gov.bc.ca/portal/*",
     "https://bcer-test.hlth.gov.bc.ca/portal/*",
     "https://d2ys4dsq8xqjer.cloudfront.net/portal/*",
+    "https://d4j0vravf4z7q.cloudfront.net/portal/*",
   ]
   web_origins = [
     "+",


### PR DESCRIPTION
### Changes being made

Updating Valid Redirect URIs for the BCER Data Portal client in Keycloak Test.

### Context

Setting up new AWS accounts for BCER.
 
### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]