### PR TITLE
Primary care new attributes

### DIFF
--- a/keycloak-test/realms/moh_applications/main.tf
+++ b/keycloak-test/realms/moh_applications/main.tf
@@ -259,7 +259,7 @@ module "PLR_UAT" {
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
 }
 module "PRIMARY-CARE" {
-  source = "./primary-care"
+  source         = "./primary-care"
   LICENCE-STATUS = module.LICENCE-STATUS
 }
 module "PRIME-DOCUMENT-MANAGER" {

--- a/keycloak-test/realms/moh_applications/main.tf
+++ b/keycloak-test/realms/moh_applications/main.tf
@@ -260,6 +260,7 @@ module "PLR_UAT" {
 }
 module "PRIMARY-CARE" {
   source = "./primary-care"
+  LICENCE-STATUS = module.LICENCE-STATUS
 }
 module "PRIME-DOCUMENT-MANAGER" {
   source = "./prime-document-manager"

--- a/keycloak-test/realms/moh_applications/primary-care/main.tf
+++ b/keycloak-test/realms/moh_applications/primary-care/main.tf
@@ -67,33 +67,33 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "bcsc_guid" {
   add_to_id_token     = false
   add_to_userinfo     = true
   add_to_access_token = true
-  claim_name      = "bcsc_guid"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "bcsc_guid"
-  user_attribute  = "bcsc_guid"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  claim_name          = "bcsc_guid"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "bcsc_guid"
+  user_attribute      = "bcsc_guid"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
 resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
   add_to_id_token     = false
   add_to_userinfo     = true
   add_to_access_token = true
-  claim_name      = "pidp_email"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "pidp_email"
-  user_attribute  = "pidp_email"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  claim_name          = "pidp_email"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "pidp_email"
+  user_attribute      = "pidp_email"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
 resource "keycloak_openid_user_attribute_protocol_mapper" "endorser_data" {
   add_to_id_token     = false
   add_to_userinfo     = true
   add_to_access_token = true
-  claim_name      = "endorser_data"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "endorser_data"
-  user_attribute  = "endorser_data"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  claim_name          = "endorser_data"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "endorser_data"
+  user_attribute      = "endorser_data"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
@@ -158,7 +158,7 @@ module "scope-mappings" {
   roles = {
     "LICENCE-STATUS/MOA"          = var.LICENCE-STATUS.ROLES["MOA"].id
     "LICENCE-STATUS/PRACTITIONER" = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
-    "LICENCE-STATUS/MD" = var.LICENCE-STATUS.ROLES["MD"].id
-    "LICENCE-STATUS/RNP" = var.LICENCE-STATUS.ROLES["RNP"].id
+    "LICENCE-STATUS/MD"           = var.LICENCE-STATUS.ROLES["MD"].id
+    "LICENCE-STATUS/RNP"          = var.LICENCE-STATUS.ROLES["RNP"].id
   }
 }

--- a/keycloak-test/realms/moh_applications/primary-care/main.tf
+++ b/keycloak-test/realms/moh_applications/primary-care/main.tf
@@ -51,6 +51,51 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper"
   add_to_userinfo             = true
 }
 
+resource "keycloak_openid_user_attribute_protocol_mapper" "common_provider_number" {
+  add_to_id_token     = false
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name          = "common_provider_number"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "common_provider_number"
+  user_attribute      = "common_provider_number"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "bcsc_guid" {
+  add_to_id_token     = false
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name      = "bcsc_guid"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "bcsc_guid"
+  user_attribute  = "bcsc_guid"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
+  add_to_id_token     = false
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name      = "pidp_email"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "pidp_email"
+  user_attribute  = "pidp_email"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "endorser_data" {
+  add_to_id_token     = false
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name      = "endorser_data"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "endorser_data"
+  user_attribute  = "endorser_data"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
@@ -66,10 +111,7 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   optional_scopes = [
-    "address",
-    "microprofile-jwt",
-    "offline_access",
-    "phone"
+    "offline_access"
   ]
 }
 
@@ -106,5 +148,15 @@ module "client-roles" {
       "name"        = "PC_HCR_Support_Tier1"
       "description" = ""
     },
+  }
+}
+
+module "scope-mappings" {
+  source    = "../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "LICENCE-STATUS/MOA"          = var.LICENCE-STATUS.ROLES["MOA"].id
+    "LICENCE-STATUS/PRACTITIONER" = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
   }
 }

--- a/keycloak-test/realms/moh_applications/primary-care/main.tf
+++ b/keycloak-test/realms/moh_applications/primary-care/main.tf
@@ -158,5 +158,7 @@ module "scope-mappings" {
   roles = {
     "LICENCE-STATUS/MOA"          = var.LICENCE-STATUS.ROLES["MOA"].id
     "LICENCE-STATUS/PRACTITIONER" = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
+    "LICENCE-STATUS/MD" = var.LICENCE-STATUS.ROLES["MD"].id
+    "LICENCE-STATUS/RNP" = var.LICENCE-STATUS.ROLES["RNP"].id
   }
 }

--- a/keycloak-test/realms/moh_applications/primary-care/variables.tf
+++ b/keycloak-test/realms/moh_applications/primary-care/variables.tf
@@ -1,0 +1,1 @@
+variable "LICENCE-STATUS" {}


### PR DESCRIPTION
### Changes being made

* Add mappers for new user attributes.
* Add scope for LICENCE-STATUS.
* Remove unused scopes.

### Context

PRIMARY-CARE needs new attributes. These attributes will eventually be added to users during PIDP enrolment.

PRIMARY-CARE also needs access to user's the LICENCE-STATUS.

I have removed some unneeded scopes in accordance with our new understanding of scopes.
 
### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in main.tf in realm root folder.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [x] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
