### PR TITLE
add pho-rsc roles

### DIFF
--- a/keycloak-dev/realms/moh_applications/pho-rsc/main.tf
+++ b/keycloak-dev/realms/moh_applications/pho-rsc/main.tf
@@ -51,7 +51,15 @@ module "client-roles" {
     "demoreports" = {
       "name"        = "demoreports"
       "description" = ""
-    }
+    },
+    "externalha" = {
+      "name"        = "externalha"
+      "description" = ""
+    },
+    "internalpho" = {
+      "name"        = "internalpho"
+      "description" = ""
+    },
   }
 }
 resource "keycloak_openid_user_client_role_protocol_mapper" "PHO-RSC-Role" {


### PR DESCRIPTION
### Changes being made

Adding two `role `resources to PHO-RSC dev. 

### Context

Roles were created manually and imported - that's why terraform plan won't show any changes. The two `roles` will actually be used as groups on the PHO-RSC side, but we don't leverage `groups` resource for individual clients. PHO-RSC is fine with passing them in token with other roles.
 
### Quality Check

- [x] Client module and all references are defined in main.tf in realm root folder.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]



[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
