### PR TITLE
add user attribute mappers to dmft-webapp

### DIFF
--- a/keycloak-dev/realms/moh_applications/dmft-webapp/main.tf
+++ b/keycloak-dev/realms/moh_applications/dmft-webapp/main.tf
@@ -31,6 +31,17 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
+resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
+  add_to_id_token     = true
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name          = "pidp_email"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "pidp_email"
+  user_attribute      = "pidp_email"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+
 module "client-roles" {
   source    = "../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-prod/realms/moh_applications/dmft-webapp/main.tf
+++ b/keycloak-prod/realms/moh_applications/dmft-webapp/main.tf
@@ -30,6 +30,17 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
+resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
+  add_to_id_token     = true
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name          = "pidp_email"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "pidp_email"
+  user_attribute      = "pidp_email"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+
 module "client-roles" {
   source    = "../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-test/realms/moh_applications/dmft-webapp/main.tf
+++ b/keycloak-test/realms/moh_applications/dmft-webapp/main.tf
@@ -33,6 +33,17 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
+resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
+  add_to_id_token     = true
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name          = "pidp_email"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "pidp_email"
+  user_attribute      = "pidp_email"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+
 module "client-roles" {
   source    = "../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id


### PR DESCRIPTION
### Changes being made

Adding User Attribute mapper for DMFT-WEBAPP clients in dev, test, and prod environments.

### Context

DMFT needs to pass `pidp_email` in its token.
 
### Quality Check

- [ ] Client module and all references are defined in main.tf in realm root folder.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
