### PR TITLE
add hsiar roles

### DIFF
--- a/keycloak-test/realms/moh_applications/hsiar/main.tf
+++ b/keycloak-test/realms/moh_applications/hsiar/main.tf
@@ -48,5 +48,11 @@ module "client-roles" {
     "Ed" = {
       "name" = "Ed"
     },
+    "HI_Operation" = {
+      "name" = "HI_Operation"
+    },
+    "HI_Consumer" = {
+      "name" = "HI_Consumer"
+    },
   }
 }


### PR DESCRIPTION
### Changes being made

Add roles for HSIAR client on TEST env.

### Context

AM Team Mailbox request.
 
### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
