### PR TITLE
Update pho rsc prod client

### DIFF
--- a/keycloak-dev/realms/moh_applications/pho-rsc/main.tf
+++ b/keycloak-dev/realms/moh_applications/pho-rsc/main.tf
@@ -28,7 +28,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://rsc-test.hlth.gov.bc.ca/*"
   ]
   web_origins = [
-    "*",
+    "+",
   ]
 }
 module "client-roles" {

--- a/keycloak-prod/realms/moh_applications/pho-rsc/main.tf
+++ b/keycloak-prod/realms/moh_applications/pho-rsc/main.tf
@@ -27,7 +27,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi*",
   ]
   web_origins = [
-    "*",
+    "+",
   ]
 }
 module "client-roles" {
@@ -45,6 +45,18 @@ module "client-roles" {
     },
     "publisher" = {
       "name"        = "publisher"
+      "description" = ""
+    },
+    "demoreports" = {
+      "name"        = "demoreports"
+      "description" = ""
+    },
+    "externalha" = {
+      "name"        = "externalha"
+      "description" = ""
+    },
+    "internalpho" = {
+      "name"        = "internalpho"
       "description" = ""
     },
   }

--- a/keycloak-prod/realms/moh_applications/user-management-service/main.tf
+++ b/keycloak-prod/realms/moh_applications/user-management-service/main.tf
@@ -88,6 +88,9 @@ module "client-roles" {
     "view-client-mspdirect-service" = {
       "name" = "view-client-mspdirect-service"
     },
+    "view-client-pho-rsc" = {
+      "name" = "view-client-pho-rsc"
+    },
     "view-client-pidp-service" = {
       "name" = "view-client-pidp-service"
     },

--- a/keycloak-prod/realms/moh_applications/user-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/user-management/main.tf
@@ -68,6 +68,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-client-maid"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-maid"].id,
     "USER-MANAGEMENT-SERVICE/view-client-miwt"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt"].id,
     "USER-MANAGEMENT-SERVICE/view-client-mspdirect-service"         = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-mspdirect-service"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-pho-rsc"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pho-rsc"].id,
     "USER-MANAGEMENT-SERVICE/view-client-pidp-service"              = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pidp-service"].id,
     "USER-MANAGEMENT-SERVICE/view-client-plr"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr"].id,
     "USER-MANAGEMENT-SERVICE/view-client-prime-application"         = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-prime-application"].id,


### PR DESCRIPTION
### Changes being made

Update PHO-RSC client on Prod environment, so it matches configuration from Dev. 
Restricting Web Origins only to redirect URIs.
Adding role to UMS/UMC so PHO-RSC roles can be assigned via UMC.

### Context

PHO-RSC moving to prod.
 
### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
