### PR TITLE
Add role external_gpid_access for prime

### DIFF
--- a/keycloak-prod/realms/moh_applications/prime-application/main.tf
+++ b/keycloak-prod/realms/moh_applications/prime-application/main.tf
@@ -24,7 +24,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://prod-9c33a9-prod.apps.silver.devops.gov.bc.ca/*",
   ]
   web_origins = [
-    "*",
+    "+",
   ]
 }
 

--- a/keycloak-prod/realms/moh_applications/prime-application/main.tf
+++ b/keycloak-prod/realms/moh_applications/prime-application/main.tf
@@ -123,6 +123,9 @@ module "client-roles" {
     "prime_api_service_account" = {
       "name" = "prime_api_service_account"
     },
+    "external_gpid_access" = {
+      "name": "external_gpid_access"
+    }
   }
 }
 

--- a/keycloak-prod/realms/moh_applications/prime-application/main.tf
+++ b/keycloak-prod/realms/moh_applications/prime-application/main.tf
@@ -124,7 +124,7 @@ module "client-roles" {
       "name" = "prime_api_service_account"
     },
     "external_gpid_access" = {
-      "name": "external_gpid_access"
+      "name" : "external_gpid_access"
     }
   }
 }

--- a/keycloak-test/realms/moh_applications/prime-application-local/main.tf
+++ b/keycloak-test/realms/moh_applications/prime-application-local/main.tf
@@ -128,7 +128,7 @@ module "client-roles" {
       "name" = "prime_api_service_account"
     },
     "external_gpid_access" = {
-      "name": "external_gpid_access"
+      "name" : "external_gpid_access"
     }
   }
 }

--- a/keycloak-test/realms/moh_applications/prime-application-local/main.tf
+++ b/keycloak-test/realms/moh_applications/prime-application-local/main.tf
@@ -127,6 +127,9 @@ module "client-roles" {
     "prime_api_service_account" = {
       "name" = "prime_api_service_account"
     },
+    "external_gpid_access" = {
+      "name": "external_gpid_access"
+    }
   }
 }
 

--- a/keycloak-test/realms/moh_applications/prime-application-local/main.tf
+++ b/keycloak-test/realms/moh_applications/prime-application-local/main.tf
@@ -22,7 +22,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "*"
   ]
   web_origins = [
-    "*",
+    "+",
   ]
 }
 

--- a/keycloak-test/realms/moh_applications/prime-application-test/main.tf
+++ b/keycloak-test/realms/moh_applications/prime-application-test/main.tf
@@ -128,7 +128,7 @@ module "client-roles" {
       "name" = "prime_api_service_account"
     },
     "external_gpid_access" = {
-      "name": "external_gpid_access"
+      "name" : "external_gpid_access"
     }
   }
 }

--- a/keycloak-test/realms/moh_applications/prime-application-test/main.tf
+++ b/keycloak-test/realms/moh_applications/prime-application-test/main.tf
@@ -127,6 +127,9 @@ module "client-roles" {
     "prime_api_service_account" = {
       "name" = "prime_api_service_account"
     },
+    "external_gpid_access" = {
+      "name": "external_gpid_access"
+    }
   }
 }
 

--- a/keycloak-test/realms/moh_applications/prime-application-test/main.tf
+++ b/keycloak-test/realms/moh_applications/prime-application-test/main.tf
@@ -22,7 +22,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "*"
   ]
   web_origins = [
-    "*",
+    "+",
   ]
 }
 


### PR DESCRIPTION
### Changes being made

Adding new role to PRIME clients

### Context

'external_gpid_access’ role will allow PRIME team to control access to API endpoint
 
### Quality Check

- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
