### PR TITLE
fix cors issue for prime

### DIFF
--- a/keycloak-test/realms/moh_applications/prime-application-local/main.tf
+++ b/keycloak-test/realms/moh_applications/prime-application-local/main.tf
@@ -22,7 +22,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "*"
   ]
   web_origins = [
-    "+",
+    "*",
   ]
 }
 

--- a/keycloak-test/realms/moh_applications/prime-application-test/main.tf
+++ b/keycloak-test/realms/moh_applications/prime-application-test/main.tf
@@ -22,7 +22,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "*"
   ]
   web_origins = [
-    "+",
+    "*",
   ]
 }
 


### PR DESCRIPTION
### Changes being made

Change `Allowed CORS Origins` to * on test clients.

### Context

PRIME has CORS issues for tests clients because `+` doesn't include `*` from Valid redirect URIs.
 
### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
