### PR TITLE
Add scope mapping for external_gpid_access

### DIFF
--- a/keycloak-prod/realms/moh_applications/prime-medinet-access/main.tf
+++ b/keycloak-prod/realms/moh_applications/prime-medinet-access/main.tf
@@ -44,6 +44,10 @@ module "service-account-roles" {
     "PRIME-APPLICATION/external_gpid_validation" = {
       "client_id" = var.PRIME-APPLICATION.CLIENT.id,
       "role_id"   = "external_gpid_validation"
+    },
+    "PRIME-APPLICATION/external_gpid_access" = {
+      "client_id" = var.PRIME-APPLICATION.CLIENT.id,
+      "role_id"   = "external_gpid_access"
     }
   }
 }
@@ -53,6 +57,7 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "PRIME-APPLICATION/external_gpid_validation" = var.PRIME-APPLICATION.ROLES["external_gpid_validation"].id
+    "PRIME-APPLICATION/external_gpid_validation" = var.PRIME-APPLICATION.ROLES["external_gpid_validation"].id,
+    "PRIME-APPLICATION/external_gpid_access"     = var.PRIME-APPLICATION.ROLES["external_gpid_access"].id
   }
 }

--- a/keycloak-test/realms/moh_applications/prime-medinet-access/main.tf
+++ b/keycloak-test/realms/moh_applications/prime-medinet-access/main.tf
@@ -48,6 +48,14 @@ module "service-account-roles" {
     "PRIME-APPLICATION-TEST/external_gpid_validation" = {
       "client_id" = var.PRIME-APPLICATION-TEST.CLIENT.id,
       "role_id"   = "external_gpid_validation"
+    },
+    "PRIME-APPLICATION-TEST/external_gpid_access" = {
+      "client_id" = var.PRIME-APPLICATION-TEST.CLIENT.id,
+      "role_id"   = "external_gpid_access"
+    },
+    "PRIME-APPLICATION-TEST/external_gpid_access" = {
+      "client_id" = var.PRIME-APPLICATION-TEST.CLIENT.id,
+      "role_id"   = "external_gpid_access"
     }
   }
 }
@@ -58,6 +66,8 @@ module "scope-mappings" {
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
     "PRIME-APPLICATION-LOCAL/external_gpid_validation" = var.PRIME-APPLICATION-LOCAL.ROLES["external_gpid_validation"].id,
-    "PRIME-APPLICATION-TEST/external_gpid_validation"  = var.PRIME-APPLICATION-TEST.ROLES["external_gpid_validation"].id
+    "PRIME-APPLICATION-TEST/external_gpid_validation"  = var.PRIME-APPLICATION-TEST.ROLES["external_gpid_validation"].id,
+    "PRIME-APPLICATION-LOCAL/external_gpid_access"     = var.PRIME-APPLICATION-LOCAL.ROLES["external_gpid_access"].id,
+    "PRIME-APPLICATION-TEST/external_gpid_access"      = var.PRIME-APPLICATION-TEST.ROLES["external_gpid_access"].id
   }
 }

--- a/keycloak-test/realms/moh_applications/prime-medinet-access/main.tf
+++ b/keycloak-test/realms/moh_applications/prime-medinet-access/main.tf
@@ -49,7 +49,7 @@ module "service-account-roles" {
       "client_id" = var.PRIME-APPLICATION-TEST.CLIENT.id,
       "role_id"   = "external_gpid_validation"
     },
-    "PRIME-APPLICATION-TEST/external_gpid_access" = {
+    "PRIME-APPLICATION-LOCAL/external_gpid_access" = {
       "client_id" = var.PRIME-APPLICATION-TEST.CLIENT.id,
       "role_id"   = "external_gpid_access"
     },


### PR DESCRIPTION
### Changes being made

Add scope mapping for external_gpid_access

### Context

Add scope mapping for external_gpid_access
 
### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
