### PR TITLE
switch remote state update readme and add test change

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Example:
   "access_key_id": "VALUE_OF_AWS_ACCESS_KEY_ID",
   "access_key_secret": "VALUE_OF_AWS_SECRET_ACCESS_KEY",
   "roles": {
-    "cey5wq_sandbox_s3_admin": "VALUE_OF_AWS_S3_BACKEND_ROLE_ARN"
+    "cey5wq_tools_s3_admin": "VALUE_OF_AWS_S3_BACKEND_ROLE_ARN"
   }
 }
 ```
@@ -102,11 +102,11 @@ The values for the `TF_VAR_ENV_client_secret` environment variables are Keycloak
 
 The Terraform state file containing Keycloak configuration is stored in an S3 bucket on the BCGOV AWS platform. In order for this to work, Terraform requires a service account with the necessary permissions to access the bucket. To fulfill this requirement, a request was submitted on the BCGOV Cloud RocketChat channel. The following is the text of the original request.
 
-> May I request a service account to have AmazonS3FullAccess Managed policy in the cey5wq-sandbox environment?
+> May I request a service account to have AmazonS3FullAccess Managed policy in the cey5wq-tools environment?
 > 
 > Assuming we create buckets prefixed with the license plate cey5wq, can we have the service account that have enough permissions to control the buckets prefixed with cey5wq? Something like this below?
 > 
-> (My intent is to store Terraform state for our Keycloak instance in a sandbox-environment S3 bucket.)
+> (My intent is to store Terraform state for our Keycloak instance in a tools-environment S3 bucket.)
 > 
 > ```json
 > {

--- a/keycloak-dev/realms/moh_applications/user-management/main.tf
+++ b/keycloak-dev/realms/moh_applications/user-management/main.tf
@@ -21,6 +21,7 @@ resource "keycloak_openid_client" "CLIENT" {
   valid_redirect_uris = [
     "http://localhost:*",
     "https://user-management-dev.hlth.gov.bc.ca/*",
+    "http://user-management-dev.hlth.gov.bc.ca/*",
     "https://localhost:*",
   ]
   web_origins = [

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_version = "~> 1.3.7"
 
   backend "s3" {
-    bucket = "cey5wq-sandbox-moh-keycloak-terraform-state"
+    bucket = "cey5wq-tools-moh-keycloak-terraform-state"
     key    = "moh-keycloak-terraform-state"
     region = "ca-central-1"
   }


### PR DESCRIPTION
### Changes being made

Changing the s3 bucket backend configuration.
Update README.md
Update the URL to test things out

### Context

AWS `sandbox` account/environment will be replaced by `tools`. Terraform state file was already transferred to `tools`. 
Updating the s3 backend config so it points to the `tools` environment.
Note: terraform plan for this PR will not work until the `AWS_S3_BACKEND_ROLE_ARN` secret is updated in the repo.
 
### Quality Check


- [x] Valid Redirect URIs are properly defined, or an explanation for `*` (allow all) is provided. 
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is an example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
