### PR TITLE
Update dmft prod client

### DIFF
--- a/keycloak-dev/realms/moh_applications/user-management/main.tf
+++ b/keycloak-dev/realms/moh_applications/user-management/main.tf
@@ -21,7 +21,6 @@ resource "keycloak_openid_client" "CLIENT" {
   valid_redirect_uris = [
     "http://localhost:*",
     "https://user-management-dev.hlth.gov.bc.ca/*",
-    "http://user-management-dev.hlth.gov.bc.ca/*",
     "https://localhost:*",
   ]
   web_origins = [

--- a/keycloak-prod/realms/moh_applications/dmft-webapp/main.tf
+++ b/keycloak-prod/realms/moh_applications/dmft-webapp/main.tf
@@ -19,10 +19,10 @@ resource "keycloak_openid_client" "CLIENT" {
   standard_flow_enabled               = true
   use_refresh_tokens                  = true
   valid_redirect_uris = [
-    "https://www.roadsafetybc.gov.bc.ca/",
-    "https://roadsafetybc.gov.bc.ca/",
-    "https://pidp-adapter-0137d5-prodapps.silver.devops.gov.bc.ca/",
-    "https://portal-ui-0137d5-prod.apps.silver.devops.gov.bc.ca/",
+    "https://www.roadsafetybc.gov.bc.ca/*",
+    "https://roadsafetybc.gov.bc.ca/*",
+    "https://pidp-adapter-0137d5-prodapps.silver.devops.gov.bc.ca/*",
+    "https://portal-ui-0137d5-prod.apps.silver.devops.gov.bc.ca/*",
     "https://rsbc-dfp-medical-portal-prod.silver.devops.bcgov/api",
   ]
   web_origins = [

--- a/keycloak-prod/realms/moh_applications/pidp-service/main.tf
+++ b/keycloak-prod/realms/moh_applications/pidp-service/main.tf
@@ -77,6 +77,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/create-user"              = var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-details"      = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-roles"        = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-dmft-webapp"  = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-dmft-webapp"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hcimweb"      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb"].id,
     "USER-MANAGEMENT-SERVICE/view-client-pidp-service" = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pidp-service"].id,
     "USER-MANAGEMENT-SERVICE/view-client-sat-eforms"   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sat-eforms"].id,
@@ -105,6 +106,10 @@ module "service-account-roles" {
     "USER-MANAGEMENT-SERVICE/manage-user-roles" = {
       "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
       "role_id"   = "manage-user-roles"
+    }
+    "USER-MANAGEMENT-SERVICE/view-client-dmft-webapp" = {
+      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
+      "role_id"   = "view-client-dmft-webapp"
     }
     "USER-MANAGEMENT-SERVICE/view-client-hcimweb" = {
       "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,

--- a/keycloak-prod/realms/moh_applications/user-management-service/main.tf
+++ b/keycloak-prod/realms/moh_applications/user-management-service/main.tf
@@ -49,6 +49,9 @@ module "client-roles" {
     "view-client-bcer-cp" = {
       "name" = "view-client-bcer-cp"
     },
+    "view-client-dmft-webapp" = {
+      "name" = "view-client-dmft-webapp"
+    },
     "view-client-eacl" = {
       "name" = "view-client-eacl"
     },

--- a/keycloak-prod/realms/moh_applications/user-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/user-management/main.tf
@@ -57,6 +57,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/manage-own-groups"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-roles"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     "USER-MANAGEMENT-SERVICE/view-client-bcer-cp"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-dmft-webappp"              = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-dmft-webapp"].id,
     "USER-MANAGEMENT-SERVICE/view-client-eacl"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl"].id,
     "USER-MANAGEMENT-SERVICE/view-client-emcod"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-emcod"].id,
     "USER-MANAGEMENT-SERVICE/view-client-fmdb"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-fmdb"].id,


### PR DESCRIPTION
### Changes being made

Added new role, scope mappings and service account role for UMC, UMS, PIDP.
Cleaned up test redirect URL.

### Context

Enabling PIDP and UMS to manage DMFT client. DMFT client transition to PROD environment.
 
### Quality Check

- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [ ] Client module and all references are defined in main.tf in realm root folder.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
