### PR TITLE
PRIMARY-CARE endorser_data should be JSON

### DIFF
--- a/keycloak-test/realms/moh_applications/primary-care/main.tf
+++ b/keycloak-test/realms/moh_applications/primary-care/main.tf
@@ -90,6 +90,7 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "endorser_data" {
   add_to_userinfo     = true
   add_to_access_token = true
   claim_name          = "endorser_data"
+  claim_value_type    = "JSON"
   client_id           = keycloak_openid_client.CLIENT.id
   name                = "endorser_data"
   user_attribute      = "endorser_data"


### PR DESCRIPTION
### Changes being made

Change the endorser_data mapper from type String (default) to JSON.

### Context

The endorser_data will be a list, e.g. 

> Multi-valued:
> `"endorser_data": ["CPN.00063660.BC.PRS","CPN.00099999.BC.PRS"]`
> 
> Single-valued:
> `"endorser_data": ["CPN.00063660.BC.PRS"]`

If you use the default String type, it will be encoded as an escaped-string, not JSON, e.g. `"endorser_data": "[\"CPN.00063660.BC.PRS\"]"`.

### Quality Check

NA

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
