### PR TITLE
Updating BC Provider mappers for PRIMARY-CARE client on test

### DIFF
--- a/keycloak-test/realms/moh_applications/primary-care/main.tf
+++ b/keycloak-test/realms/moh_applications/primary-care/main.tf
@@ -66,10 +66,10 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
   add_to_id_token     = false
   add_to_userinfo     = true
   add_to_access_token = true
-  claim_name          = "pidp_email"
+  claim_name          = "pidpEmail"
   client_id           = keycloak_openid_client.CLIENT.id
   name                = "pidp_email"
-  user_attribute      = "pidp_email"
+  user_attribute      = "pidpEmail"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
@@ -89,10 +89,10 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "is_md" {
   add_to_id_token     = false
   add_to_userinfo     = true
   add_to_access_token = true
-  claim_name          = "is_md"
+  claim_name          = "isMd"
   client_id           = keycloak_openid_client.CLIENT.id
   name                = "is_md"
-  user_attribute      = "is_md"
+  user_attribute      = "isMd"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
@@ -100,10 +100,10 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "is_moa" {
   add_to_id_token     = false
   add_to_userinfo     = true
   add_to_access_token = true
-  claim_name          = "is_moa"
+  claim_name          = "isMoa"
   client_id           = keycloak_openid_client.CLIENT.id
   name                = "is_moa"
-  user_attribute      = "is_moa"
+  user_attribute      = "isMoa"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
@@ -111,10 +111,10 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "is_rnp" {
   add_to_id_token     = false
   add_to_userinfo     = true
   add_to_access_token = true
-  claim_name          = "is_rnp"
+  claim_name          = "isRnp"
   client_id           = keycloak_openid_client.CLIENT.id
   name                = "is_rnp"
-  user_attribute      = "is_rnp"
+  user_attribute      = "isRnp"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
@@ -145,7 +145,6 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "cpn" {
   add_to_userinfo     = true
   add_to_access_token = true
   claim_name          = "cpn"
-  claim_value_type    = "String"
   client_id           = keycloak_openid_client.CLIENT.id
   name                = "cpn"
   user_attribute      = "cpn"


### PR DESCRIPTION
### Changes being made

Updating BC Provider mappers for PRIMARY-CARE client on test

### Quality Check
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
