### PR TITLE
new role for hsiar on test env

### DIFF
--- a/keycloak-test/realms/moh_applications/hsiar/main.tf
+++ b/keycloak-test/realms/moh_applications/hsiar/main.tf
@@ -54,6 +54,9 @@ module "client-roles" {
     "HI_Consumer" = {
       "name" = "HI_Consumer"
     },
+    "HSPP_ALL" = {
+      "name" = "HSPP_ALL"
+    },
     "HSPP_HumanResource" = {
       "name" = "HSPP_HumanResource"
     },


### PR DESCRIPTION
### Changes being made

New role for HSIAR on test env
 
### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with the existing configuration, they can be ignored. Here is an example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
