### PR TITLE
PRIMARY-CARE: Add attributes to ID token. Remove unused attributes.

### DIFF
--- a/keycloak-test/realms/moh_applications/primary-care/main.tf
+++ b/keycloak-test/realms/moh_applications/primary-care/main.tf
@@ -38,11 +38,24 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
-resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper" {
+resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper-PRIMARY-CARE" {
   realm_id                    = keycloak_openid_client.CLIENT.realm_id
   client_id                   = keycloak_openid_client.CLIENT.id
   client_id_for_role_mappings = "PRIMARY-CARE"
-  name                        = "Client Role Mapper"
+  name                        = "Client Role Mapper for PRIMARY-CARE"
+  claim_name                  = "roles"
+  multivalued                 = true
+  claim_value_type            = "String"
+  add_to_id_token             = true
+  add_to_access_token         = true
+  add_to_userinfo             = true
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper-LICENCE-STATUS" {
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "LICENCE-STATUS"
+  name                        = "Client Role Mapper for LICENCE-STATUS"
   claim_name                  = "roles"
   multivalued                 = true
   claim_value_type            = "String"
@@ -52,7 +65,7 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper"
 }
 
 resource "keycloak_openid_user_attribute_protocol_mapper" "bcsc_guid" {
-  add_to_id_token     = false
+  add_to_id_token     = true
   add_to_userinfo     = true
   add_to_access_token = true
   claim_name          = "bcsc_guid"
@@ -63,18 +76,18 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "bcsc_guid" {
 }
 
 resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
-  add_to_id_token     = false
+  add_to_id_token     = true
   add_to_userinfo     = true
   add_to_access_token = true
-  claim_name          = "pidpEmail"
+  claim_name          = "pidp_email"
   client_id           = keycloak_openid_client.CLIENT.id
   name                = "pidp_email"
-  user_attribute      = "pidpEmail"
+  user_attribute      = "pidp_email"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
 resource "keycloak_openid_user_attribute_protocol_mapper" "endorser_data" {
-  add_to_id_token     = false
+  add_to_id_token     = true
   add_to_userinfo     = true
   add_to_access_token = true
   claim_name          = "endorser_data"
@@ -82,39 +95,6 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "endorser_data" {
   client_id           = keycloak_openid_client.CLIENT.id
   name                = "endorser_data"
   user_attribute      = "endorser_data"
-  realm_id            = keycloak_openid_client.CLIENT.realm_id
-}
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "is_md" {
-  add_to_id_token     = false
-  add_to_userinfo     = true
-  add_to_access_token = true
-  claim_name          = "isMd"
-  client_id           = keycloak_openid_client.CLIENT.id
-  name                = "is_md"
-  user_attribute      = "isMd"
-  realm_id            = keycloak_openid_client.CLIENT.realm_id
-}
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "is_moa" {
-  add_to_id_token     = false
-  add_to_userinfo     = true
-  add_to_access_token = true
-  claim_name          = "isMoa"
-  client_id           = keycloak_openid_client.CLIENT.id
-  name                = "is_moa"
-  user_attribute      = "isMoa"
-  realm_id            = keycloak_openid_client.CLIENT.realm_id
-}
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "is_rnp" {
-  add_to_id_token     = false
-  add_to_userinfo     = true
-  add_to_access_token = true
-  claim_name          = "isRnp"
-  client_id           = keycloak_openid_client.CLIENT.id
-  name                = "is_rnp"
-  user_attribute      = "isRnp"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
@@ -129,19 +109,8 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "hpdid" {
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "user_oid" {
-  add_to_id_token     = false
-  add_to_userinfo     = true
-  add_to_access_token = true
-  claim_name          = "user_oid"
-  client_id           = keycloak_openid_client.CLIENT.id
-  name                = "user_oid"
-  user_attribute      = "user_oid"
-  realm_id            = keycloak_openid_client.CLIENT.realm_id
-}
-
 resource "keycloak_openid_user_attribute_protocol_mapper" "cpn" {
-  add_to_id_token     = false
+  add_to_id_token     = true
   add_to_userinfo     = true
   add_to_access_token = true
   claim_name          = "cpn"


### PR DESCRIPTION
### Changes being made

Add existing attributes to access token. Remove unused attributes.

### Context

PRIMARY-CARE has requested attributes be added to the ID token, not just the access token. 

Some of the attributes that were recently added, e.g. `isMd`, will not be needed directly, but will be mapped into a client role for the LICENCE-STATUS client. Mappers have been removed. IDP mappers will be added to map `isMd` into a client role.
 
### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in main.tf in realm root folder.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [x] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
