### PR TITLE
add role for hsiar and redirect url for tpl

### DIFF
--- a/keycloak-test/realms/moh_applications/hsiar/main.tf
+++ b/keycloak-test/realms/moh_applications/hsiar/main.tf
@@ -42,17 +42,20 @@ module "client-roles" {
   client_id = keycloak_openid_client.CLIENT.id
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   roles = {
-    "Surgical" = {
-      "name" = "Surgical"
+    "AD_Education" = {
+      "name" = "AD_Education"
     },
     "Ed" = {
       "name" = "Ed"
     },
-    "HI_Operation" = {
-      "name" = "HI_Operation"
+    "HI_Administrator" = {
+      "name" = "HI_Administrator"
     },
     "HI_Consumer" = {
       "name" = "HI_Consumer"
+    },
+    "HI_Operation" = {
+      "name" = "HI_Operation"
     },
     "HSPP_ALL" = {
       "name" = "HSPP_ALL"
@@ -63,11 +66,11 @@ module "client-roles" {
     "HSPP_OKR" = {
       "name" = "HSPP_OKR"
     },
-    "AD_Education" = {
-      "name" = "AD_Education"
+    "ITSB_DIGI" = {
+      "name" = "ITSB_DIGI"
     },
-    "HI_Administrator" = {
-      "name" = "HI_Administrator"
+    "Surgical" = {
+      "name" = "Surgical"
     },
   }
 }

--- a/keycloak-test/realms/moh_applications/tpl/main.tf
+++ b/keycloak-test/realms/moh_applications/tpl/main.tf
@@ -22,6 +22,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://bcmohtpl--keycloak.sandbox.my.salesforce.com/*",
     "https://bcmohtpl--tplqaa.sandbox.my.salesforce.com/*",
     "https://bcmohtpl--tpluat.sandbox.my.salesforce.com/*",
+    "https://bcmohtpl--tpldata.sandbox.my.salesforce.com/*"
   ]
   web_origins = [
   ]


### PR DESCRIPTION
### Changes being made

Added new role for HSIAR test env (ITSB_DIGI), rearranged the order to alphabetical. Added new redirect URI for TPL. 
 
### Quality Check

- [x] Valid Redirect URIs are properly defined, or an explanation for `*` (allow all) is provided. 
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with the existing configuration, they can be ignored. Here is an example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
