### PR TITLE
add uris for primary care and prp

### DIFF
--- a/keycloak-dev/realms/moh_applications/prp-web/main.tf
+++ b/keycloak-dev/realms/moh_applications/prp-web/main.tf
@@ -14,6 +14,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://wonderful-cliff-0d1cec610.2.azurestaticapps.net/*",
     "https://devprp.hlth.gov.bc.ca/*",
     "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
+    "https://login.microsoftonline.com/common/oauth2/v2.0/logout*",
   ]
   web_origins = [
     "*",

--- a/keycloak-test/realms/moh_applications/primary-care/main.tf
+++ b/keycloak-test/realms/moh_applications/primary-care/main.tf
@@ -33,6 +33,9 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://healthbc--hlthbcstx.sandbox.my.site.com/*",
     "https://healthbc--hlthbcuat.sandbox.my.salesforce.com/*",
     "https://healthbc--hlthbcuat.sandbox.my.site.com/*",
+    "https://healthbc--hlthbcdevn.sandbox.my.salesforce.com/*",
+    "https://healthbc--hlthbcdevn.sandbox.my.site.com/*"
+
   ]
   web_origins = [
   ]


### PR DESCRIPTION
### Changes being made
Adding redirect URIs from PRIMARY-CARE on test env and PRP-WEB on dev.
PRP-WEB changes won't show up on plan as they were added manually.
 
### Quality Check

- [ ] Valid Redirect URIs are properly defined, or an explanation for `*` (allow all) is provided. 
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with the existing configuration, they can be ignored. Here is an example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
