### PR TITLE
manage realm roles on prod env

### DIFF
--- a/keycloak-prod/realms/moh_applications/realm-roles/cgi-application-support/main.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/cgi-application-support/main.tf
@@ -1,0 +1,15 @@
+resource "keycloak_role" "REALM_ROLE" {
+  composite_roles = [
+    var.BCER-CP.ROLES["bcer_admin"].id,
+    var.EACL.ROLES["Super_Sysadmin"].id,
+    var.FMDB.ROLES["MOHUSER"].id,
+    var.HEM.ROLES["hem"].id,
+    var.MIWT.ROLES["MEDIMADMIN"].id,
+    var.MSPDIRECT-SERVICE.ROLES["TRAININGHEALTHAUTH"].id,
+    var.SFDS.ROLES["ADMIN"].id,
+    var.SWT.ROLES["Administrator"].id,
+  ]
+  description = "Provides the top level of access to all CGI managed applications."
+  name        = "CGI Application Support"
+  realm_id    = "moh_applications"
+}

--- a/keycloak-prod/realms/moh_applications/realm-roles/cgi-application-support/output.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/cgi-application-support/output.tf
@@ -1,0 +1,3 @@
+output "REALM_ROLE" {
+  value = keycloak_role.REALM_ROLE
+}

--- a/keycloak-prod/realms/moh_applications/realm-roles/cgi-application-support/variables.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/cgi-application-support/variables.tf
@@ -1,0 +1,8 @@
+variable "BCER-CP" {}
+variable "EACL" {}
+variable "FMDB" {}
+variable "HEM" {}
+variable "MIWT" {}
+variable "MSPDIRECT-SERVICE" {}
+variable "SFDS" {}
+variable "SWT" {}

--- a/keycloak-prod/realms/moh_applications/realm-roles/cgi-application-support/versions.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/cgi-application-support/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-prod/realms/moh_applications/realm-roles/manage-realm/main.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/manage-realm/main.tf
@@ -1,0 +1,24 @@
+resource "keycloak_role" "REALM_ROLE" {
+  composite_roles = [
+    var.realm-management.ROLES["create-client"].id,
+    var.realm-management.ROLES["manage-authorization"].id,
+    var.realm-management.ROLES["manage-clients"].id,
+    var.realm-management.ROLES["manage-events"].id,
+    var.realm-management.ROLES["manage-identity-providers"].id,
+    var.realm-management.ROLES["manage-realm"].id,
+    var.realm-management.ROLES["manage-users"].id,
+    var.realm-management.ROLES["query-clients"].id,
+    var.realm-management.ROLES["query-groups"].id,
+    var.realm-management.ROLES["query-realms"].id,
+    var.realm-management.ROLES["query-users"].id,
+    var.realm-management.ROLES["view-authorization"].id,
+    var.realm-management.ROLES["view-clients"].id,
+    var.realm-management.ROLES["view-events"].id,
+    var.realm-management.ROLES["view-identity-providers"].id,
+    var.realm-management.ROLES["view-realm"].id,
+    var.realm-management.ROLES["view-users"].id,
+  ]
+  description = "Provides the required ream-management roles to manage all aspects of this realm. In PROD this role is provided to the Midtier team."
+  name        = "Manage Realm"
+  realm_id    = "moh_applications"
+}

--- a/keycloak-prod/realms/moh_applications/realm-roles/manage-realm/output.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/manage-realm/output.tf
@@ -1,0 +1,3 @@
+output "REALM_ROLE" {
+  value = keycloak_role.REALM_ROLE
+}

--- a/keycloak-prod/realms/moh_applications/realm-roles/manage-realm/variables.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/manage-realm/variables.tf
@@ -1,0 +1,1 @@
+variable "realm-management" {}

--- a/keycloak-prod/realms/moh_applications/realm-roles/manage-realm/versions.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/manage-realm/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-prod/realms/moh_applications/realm-roles/manage-users/main.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/manage-users/main.tf
@@ -1,0 +1,34 @@
+resource "keycloak_role" "REALM_ROLE" {
+  composite_roles = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-all-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-org"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-fmdb"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-gis"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hamis"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hem"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hscis"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-maid"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-mspdirect-service"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-prime-application"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sfds"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-swt"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-tap"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-metrics"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
+    var.USER-MANAGEMENT.ROLES["user-management-admin"].id,
+  ]
+  description = "Provides the roles required to manage users using the USER-MANAGEMENT application including roles for all applications. In PROD this role is not provided to specific teams."
+  name        = "Manage Users"
+  realm_id    = "moh_applications"
+}

--- a/keycloak-prod/realms/moh_applications/realm-roles/manage-users/output.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/manage-users/output.tf
@@ -1,0 +1,3 @@
+output "REALM_ROLE" {
+  value = keycloak_role.REALM_ROLE
+}

--- a/keycloak-prod/realms/moh_applications/realm-roles/manage-users/variables.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/manage-users/variables.tf
@@ -1,0 +1,2 @@
+variable "USER-MANAGEMENT" {}
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-prod/realms/moh_applications/realm-roles/manage-users/versions.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/manage-users/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-prod/realms/moh_applications/realm-roles/view-users/main.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/view-users/main.tf
@@ -1,0 +1,27 @@
+resource "keycloak_role" "REALM_ROLE" {
+  composite_roles = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-fmdb"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-gis"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hamis"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hem"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hscis"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-maid"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-dbaac-portal"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-hibc-service-bc-portal"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-sfdc"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sfds"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-swt"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
+  ]
+  description = "View-only role for User Management Console"
+  name        = "View Users"
+  realm_id    = "moh_applications"
+}

--- a/keycloak-prod/realms/moh_applications/realm-roles/view-users/output.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/view-users/output.tf
@@ -1,0 +1,3 @@
+output "REALM_ROLE" {
+  value = keycloak_role.REALM_ROLE
+}

--- a/keycloak-prod/realms/moh_applications/realm-roles/view-users/variables.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/view-users/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-prod/realms/moh_applications/realm-roles/view-users/versions.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/view-users/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-prod/realms/moh_applications/realmRoles.tf
+++ b/keycloak-prod/realms/moh_applications/realmRoles.tf
@@ -1,0 +1,24 @@
+module "CGI-APPLICATION-SUPPORT" {
+  source            = "./realm-roles/cgi-application-support"
+  BCER-CP           = module.BCER-CP
+  EACL              = module.EACL
+  FMDB              = module.FMDB
+  HEM               = module.HEM
+  MIWT              = module.MIWT
+  MSPDIRECT-SERVICE = module.MSPDIRECT-SERVICE
+  SFDS              = module.SFDS
+  SWT               = module.SWT
+}
+module "MANAGE-REALM" {
+  source           = "./realm-roles/manage-realm"
+  realm-management = module.realm-management
+}
+module "MANAGE-USERS" {
+  source                  = "./realm-roles/manage-users"
+  USER-MANAGEMENT         = module.USER-MANAGEMENT
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+module "VIEW-USERS" {
+  source                  = "./realm-roles/view-users"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}


### PR DESCRIPTION
### Changes being made

Add realm roles to the prod environment. Realm roles were imported.
 
### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
