### PR TITLE
PRIMARY-CARE: Create client in PROD.

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients.tf
+++ b/keycloak-prod/realms/moh_applications/clients.tf
@@ -118,6 +118,10 @@ module "PIDP-WEBAPP" {
 module "PLR" {
   source = "./clients/plr"
 }
+module "PRIMARY-CARE" {
+  source         = "./clients/primary-care"
+  LICENCE-STATUS = module.LICENCE-STATUS
+}
 module "PRIME-APPLICATION" {
   source  = "./clients/prime-application"
   account = module.account

--- a/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
@@ -1,0 +1,167 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "PRIMARY-CARE"
+  consent_required                    = false
+  description                         = "Primary Care"
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "Primary Care"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = false
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper-PRIMARY-CARE" {
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "PRIMARY-CARE"
+  name                        = "Client Role Mapper for PRIMARY-CARE"
+  claim_name                  = "roles"
+  multivalued                 = true
+  claim_value_type            = "String"
+  add_to_id_token             = true
+  add_to_access_token         = true
+  add_to_userinfo             = true
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper-LICENCE-STATUS" {
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "LICENCE-STATUS"
+  name                        = "Client Role Mapper for LICENCE-STATUS"
+  claim_name                  = "roles"
+  multivalued                 = true
+  claim_value_type            = "String"
+  add_to_id_token             = true
+  add_to_access_token         = true
+  add_to_userinfo             = true
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "bcsc_guid" {
+  add_to_id_token     = true
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name          = "bcsc_guid"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "bcsc_guid"
+  user_attribute      = "bcsc_guid"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
+  add_to_id_token     = true
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name          = "pidp_email"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "pidp_email"
+  user_attribute      = "pidp_email"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "endorser_data" {
+  add_to_id_token     = true
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name          = "endorser_data"
+  claim_value_type    = "JSON"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "endorser_data"
+  user_attribute      = "endorser_data"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "cpn" {
+  add_to_id_token     = true
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name          = "common_provider_number"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "cpn"
+  user_attribute      = "common_provider_number"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "email",
+    "profile",
+    "roles",
+    "web-origins"
+  ]
+}
+
+resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  optional_scopes = [
+    "offline_access"
+  ]
+}
+
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "PC_Patient" = {
+      "name"        = "PC_Patient"
+      "description" = ""
+    },
+    "PC_Practitioner" = {
+      "name"        = "PC_Practitioner"
+      "description" = ""
+    },
+    "IMITS_PC_System_Admin" = {
+      "name"        = "IMITS_PC_System_Admin"
+      "description" = ""
+    },
+    "IMITS_PC_Ops_Support" = {
+      "name"        = "IMITS_PC_Ops_Support"
+      "description" = ""
+    },
+    "PC_Attachment_Coordinator" = {
+      "name"        = "PC_Attachment_Coordinator"
+      "description" = ""
+    },
+    "PC_HCR_Support_Tier2" = {
+      "name"        = "PC_HCR_Support_Tier2"
+      "description" = ""
+    },
+    "PC_HCR_Support_Tier1" = {
+      "name"        = "PC_HCR_Support_Tier1"
+      "description" = ""
+    },
+    "PC_Navigator" = {
+      "name"        = "PC_Navigator"
+      "description" = ""
+    },
+  }
+}
+
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "LICENCE-STATUS/MOA"          = var.LICENCE-STATUS.ROLES["MOA"].id
+    "LICENCE-STATUS/PRACTITIONER" = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
+    "LICENCE-STATUS/MD"           = var.LICENCE-STATUS.ROLES["MD"].id
+    "LICENCE-STATUS/RNP"          = var.LICENCE-STATUS.ROLES["RNP"].id
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/primary-care/outputs.tf
+++ b/keycloak-prod/realms/moh_applications/clients/primary-care/outputs.tf
@@ -1,0 +1,6 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}
+output "ROLES" {
+  value = module.client-roles.ROLES
+}

--- a/keycloak-prod/realms/moh_applications/clients/primary-care/variables.tf
+++ b/keycloak-prod/realms/moh_applications/clients/primary-care/variables.tf
@@ -1,0 +1,1 @@
+variable "LICENCE-STATUS" {}

--- a/keycloak-prod/realms/moh_applications/clients/primary-care/versions.tf
+++ b/keycloak-prod/realms/moh_applications/clients/primary-care/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Promote the PRIMARY-CARE client to PROD.

### Context

We have been requested to set-up some PRIMARY-CARE users in PROD. This isn't really in the right sequence, as PRIMARY-CARE has not been deployed to PROD yet, so any users we won't set-up aren't usable or testable. In any case, we need a client with roles if we're to assign them to users, so we're promoting the client to PROD now. It's not a security risk, but it will likely require changes as they are still requesting configuration changes in TEST.
 
### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in main.tf in realm root folder.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [x] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
