### PR TITLE
PRIMARY-CARE: Add redirect URL. Requires at least one. 

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
@@ -19,6 +19,7 @@ resource "keycloak_openid_client" "CLIENT" {
   standard_flow_enabled               = true
   use_refresh_tokens                  = false
   valid_redirect_uris = [
+    "https://cgi.com/"
   ]
   web_origins = [
   ]


### PR DESCRIPTION
This is just a placeholder URL. Not the real one.
