### PR TITLE
PRIME-VIHACERNER-ACCESS: create service account in test

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -294,6 +294,11 @@ module "PRIME-CARECONNECT-ACCESS" {
   PRIME-APPLICATION-LOCAL = module.PRIME-APPLICATION-LOCAL
   PRIME-APPLICATION-TEST  = module.PRIME-APPLICATION-TEST
 }
+module "PRIME-VIHACERNER-ACCESS" {
+  source                  = "./clients/prime-vihacerner-access"
+  PRIME-APPLICATION-LOCAL = module.PRIME-APPLICATION-LOCAL
+  PRIME-APPLICATION-TEST  = module.PRIME-APPLICATION-TEST
+}
 module "PRIME-WEBAPP-ENROLLMENT" {
   source  = "./clients/prime-webapp-enrollment"
   account = module.account

--- a/keycloak-test/realms/moh_applications/clients/prime-vihacerner-access/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prime-vihacerner-access/main.tf
@@ -1,0 +1,63 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "PRIME-VIHACERNER-ACCESS"
+  consent_required                    = false
+  description                         = ""
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = ""
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = true
+  standard_flow_enabled               = false
+  use_refresh_tokens                  = false
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+
+resource "keycloak_openid_audience_protocol_mapper" "prime-web-api" {
+  add_to_id_token          = false
+  client_id                = keycloak_openid_client.CLIENT.id
+  included_custom_audience = "prime-web-api"
+  name                     = "prime-web-api"
+  realm_id                 = keycloak_openid_client.CLIENT.realm_id
+}
+
+module "service-account-roles" {
+  source                  = "../../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {
+    "PRIME-APPLICATION-LOCAL/external_hpdid_access" = {
+      "client_id" = var.PRIME-APPLICATION-LOCAL.CLIENT.id,
+      "role_id"   = "external_hpdid_access"
+    },
+    "PRIME-APPLICATION-TEST/external_hpdid_access" = {
+      "client_id" = var.PRIME-APPLICATION-TEST.CLIENT.id,
+      "role_id"   = "external_hpdid_access"
+    }
+  }
+}
+
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "PRIME-APPLICATION-LOCAL/external_hpdid_access" = var.PRIME-APPLICATION-LOCAL.ROLES["external_hpdid_access"].id,
+    "PRIME-APPLICATION-TEST/external_hpdid_access"  = var.PRIME-APPLICATION-TEST.ROLES["external_hpdid_access"].id
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/prime-vihacerner-access/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/prime-vihacerner-access/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/prime-vihacerner-access/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/prime-vihacerner-access/variables.tf
@@ -1,0 +1,2 @@
+variable "PRIME-APPLICATION-LOCAL" {}
+variable "PRIME-APPLICATION-TEST" {}

--- a/keycloak-test/realms/moh_applications/clients/prime-vihacerner-access/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/prime-vihacerner-access/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Creating PRIME-VIHACERNER-ACCESS service account in the test environment.

### Context

A new system account for Island Health was requested. The account should be similar to PRIME-CARECONNECT-ACCESS, but named PRIME-VIHACERNER-ACCESS?

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Client module and all references are defined in main.tf in realm root folder.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
