### PR TITLE
update primary-care roles

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
@@ -124,18 +124,6 @@ module "client-roles" {
       "name"        = "PC_Patient"
       "description" = ""
     },
-    "PC_Practitioner" = {
-      "name"        = "PC_Practitioner"
-      "description" = ""
-    },
-    "IMITS_PC_System_Admin" = {
-      "name"        = "IMITS_PC_System_Admin"
-      "description" = ""
-    },
-    "IMITS_PC_Ops_Support" = {
-      "name"        = "IMITS_PC_Ops_Support"
-      "description" = ""
-    },
     "PC_Attachment_Coordinator" = {
       "name"        = "PC_Attachment_Coordinator"
       "description" = ""
@@ -150,6 +138,14 @@ module "client-roles" {
     },
     "PC_Navigator" = {
       "name"        = "PC_Navigator"
+      "description" = ""
+    },
+    "PC_Provider_Support_Tier0" = {
+      "name"        = "PC_Provider_Support_Tier0"
+      "description" = ""
+    },
+    "PC_Reporting_User" = {
+      "name"        = "PC_Reporting_User"
       "description" = ""
     },
   }

--- a/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
@@ -140,18 +140,6 @@ module "client-roles" {
       "name"        = "PC_Patient"
       "description" = ""
     },
-    "PC_Practitioner" = {
-      "name"        = "PC_Practitioner"
-      "description" = ""
-    },
-    "IMITS_PC_System_Admin" = {
-      "name"        = "IMITS_PC_System_Admin"
-      "description" = ""
-    },
-    "IMITS_PC_Ops_Support" = {
-      "name"        = "IMITS_PC_Ops_Support"
-      "description" = ""
-    },
     "PC_Attachment_Coordinator" = {
       "name"        = "PC_Attachment_Coordinator"
       "description" = ""
@@ -166,6 +154,14 @@ module "client-roles" {
     },
     "PC_Navigator" = {
       "name"        = "PC_Navigator"
+      "description" = ""
+    },
+    "PC_Provider_Support_Tier0" = {
+      "name"        = "PC_Provider_Support_Tier0"
+      "description" = ""
+    },
+    "PC_Reporting_User" = {
+      "name"        = "PC_Reporting_User"
       "description" = ""
     },
   }


### PR DESCRIPTION
### Changes being made

Add/ remove roles from PRIMARY-CARE client on test and prod environments. 

### Context

PRIMARY-CARE updated a list of Salesforce Personas, changes need to be reflected in Keycloak.
 
### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with the existing configuration, they can be ignored. Here is an example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
