### PR TITLE
add view-client-primary-care role to ManageUsers in Prod

### DIFF
--- a/keycloak-prod/realms/moh_applications/realm-roles/manage-users/main.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/manage-users/main.tf
@@ -17,6 +17,7 @@ resource "keycloak_role" "REALM_ROLE" {
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-mspdirect-service"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-primary-care"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-prime-application"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sfds"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-swt"].id,


### PR DESCRIPTION
### Changes being made

Add view-client-primary-care role to ManageUsers in Prod env.

### Context

This role is needed to manage PRIMARY-CARE client in UMC.
 
### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
