### PR TITLE
import keycloak groups to  terraform on dev env

### DIFF
--- a/keycloak-dev/realms/moh_applications/groups.tf
+++ b/keycloak-dev/realms/moh_applications/groups.tf
@@ -1,0 +1,53 @@
+module "CGI-DBA" {
+  source                  = "./groups/cgi-dba"
+  CGI-APPLICATION-SUPPORT = module.CGI-APPLICATION-SUPPORT
+  MANAGE-REALM            = module.MANAGE-REALM
+  MANAGE-USERS            = module.MANAGE-USERS
+}
+module "CGI-DEVELOPER" {
+  source                  = "./groups/cgi-developer"
+  CGI-APPLICATION-SUPPORT = module.CGI-APPLICATION-SUPPORT
+  HEM                     = module.HEM
+  MANAGE-USERS            = module.MANAGE-USERS
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+module "CGI-MID-TIER" {
+  source                  = "./groups/cgi-mid-tier"
+  CGI-APPLICATION-SUPPORT = module.CGI-APPLICATION-SUPPORT
+  HEM                     = module.HEM
+  MANAGE-USERS            = module.MANAGE-USERS
+}
+module "CGI-QA" {
+  source                  = "./groups/cgi-qa"
+  CGI-APPLICATION-SUPPORT = module.CGI-APPLICATION-SUPPORT
+  HEM                     = module.HEM
+  MANAGE-USERS            = module.MANAGE-USERS
+}
+module "EMCOD-HELP-DESK" {
+  source                  = "./groups/emcod-help-desk"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+module "ITSB-ACCESS-TEAM" {
+  source                  = "./groups/itsb-access-team"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+  realm-management        = module.realm-management
+}
+module "PIDP-MANAGEMENT" {
+  source                  = "./groups/pidp-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+  realm-management        = module.realm-management
+}
+module "REGISTRIES-ACCESS-TEAM" {
+  source           = "./groups/registries-access-team"
+  realm-management = module.realm-management
+}
+module "SAT-ACCESS-MANAGEMENT" {
+  source                  = "./groups/sat-access-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+  realm-management        = module.realm-management
+}
+module "WEBCAPS-USER-ADMIN" {
+  source                  = "./groups/webcaps-user-admin"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+  realm-management        = module.realm-management
+}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-dba/main.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-dba/main.tf
@@ -1,0 +1,15 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "CGI DBA"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.CGI-APPLICATION-SUPPORT.REALM_ROLE.id,
+    var.MANAGE-REALM.REALM_ROLE.id,
+    var.MANAGE-USERS.REALM_ROLE.id
+  ]
+}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-dba/output.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-dba/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-dba/variables.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-dba/variables.tf
@@ -1,0 +1,3 @@
+variable "CGI-APPLICATION-SUPPORT" {}
+variable "MANAGE-REALM" {}
+variable "MANAGE-USERS" {}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-dba/versions.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-dba/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-developer/main.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-developer/main.tf
@@ -1,0 +1,16 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "CGI Developer"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.CGI-APPLICATION-SUPPORT.REALM_ROLE.id,
+    var.HEM.ROLES["hem"].id,
+    var.MANAGE-USERS.REALM_ROLE.id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-metrics"].id
+  ]
+}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-developer/output.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-developer/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-developer/variables.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-developer/variables.tf
@@ -1,0 +1,4 @@
+variable "CGI-APPLICATION-SUPPORT" {}
+variable "HEM" {}
+variable "MANAGE-USERS" {}
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-developer/versions.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-developer/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-mid-tier/main.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-mid-tier/main.tf
@@ -1,0 +1,15 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "CGI Mid-tier"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.CGI-APPLICATION-SUPPORT.REALM_ROLE.id,
+    var.HEM.ROLES["hem"].id,
+    var.MANAGE-USERS.REALM_ROLE.id
+  ]
+}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-mid-tier/output.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-mid-tier/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-mid-tier/variables.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-mid-tier/variables.tf
@@ -1,0 +1,3 @@
+variable "CGI-APPLICATION-SUPPORT" {}
+variable "HEM" {}
+variable "MANAGE-USERS" {}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-mid-tier/versions.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-mid-tier/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-qa/main.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-qa/main.tf
@@ -1,0 +1,15 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "CGI QA"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.CGI-APPLICATION-SUPPORT.REALM_ROLE.id,
+    var.HEM.ROLES["hem"].id,
+    var.MANAGE-USERS.REALM_ROLE.id
+  ]
+}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-qa/output.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-qa/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-qa/variables.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-qa/variables.tf
@@ -1,0 +1,3 @@
+variable "CGI-APPLICATION-SUPPORT" {}
+variable "HEM" {}
+variable "MANAGE-USERS" {}

--- a/keycloak-dev/realms/moh_applications/groups/cgi-qa/versions.tf
+++ b/keycloak-dev/realms/moh_applications/groups/cgi-qa/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-dev/realms/moh_applications/groups/emcod-help-desk/main.tf
+++ b/keycloak-dev/realms/moh_applications/groups/emcod-help-desk/main.tf
@@ -1,0 +1,20 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "EMCOD Help Desk"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-emcod"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-dev/realms/moh_applications/groups/emcod-help-desk/output.tf
+++ b/keycloak-dev/realms/moh_applications/groups/emcod-help-desk/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-dev/realms/moh_applications/groups/emcod-help-desk/variables.tf
+++ b/keycloak-dev/realms/moh_applications/groups/emcod-help-desk/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-dev/realms/moh_applications/groups/emcod-help-desk/versions.tf
+++ b/keycloak-dev/realms/moh_applications/groups/emcod-help-desk/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-dev/realms/moh_applications/groups/itsb-access-team/main.tf
+++ b/keycloak-dev/realms/moh_applications/groups/itsb-access-team/main.tf
@@ -1,0 +1,28 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "ITSB Access Team"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hem"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-dbaac-portal"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-hibc-service-bc-portal"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-sfdc"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
+    var.realm-management.ROLES["manage-users"].id,
+    var.realm-management.ROLES["query-clients"].id,
+    var.realm-management.ROLES["view-events"].id,
+    var.realm-management.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-dev/realms/moh_applications/groups/itsb-access-team/output.tf
+++ b/keycloak-dev/realms/moh_applications/groups/itsb-access-team/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-dev/realms/moh_applications/groups/itsb-access-team/variables.tf
+++ b/keycloak-dev/realms/moh_applications/groups/itsb-access-team/variables.tf
@@ -1,0 +1,2 @@
+variable "USER-MANAGEMENT-SERVICE" {}
+variable "realm-management" {}

--- a/keycloak-dev/realms/moh_applications/groups/itsb-access-team/versions.tf
+++ b/keycloak-dev/realms/moh_applications/groups/itsb-access-team/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-dev/realms/moh_applications/groups/pidp-management/main.tf
+++ b/keycloak-dev/realms/moh_applications/groups/pidp-management/main.tf
@@ -1,0 +1,24 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "PIdP Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-dmft-webapp"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-licence-status"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pidp-service"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
+    var.realm-management.ROLES["query-clients"].id,
+    var.realm-management.ROLES["view-clients"].id
+  ]
+}

--- a/keycloak-dev/realms/moh_applications/groups/pidp-management/output.tf
+++ b/keycloak-dev/realms/moh_applications/groups/pidp-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-dev/realms/moh_applications/groups/pidp-management/variables.tf
+++ b/keycloak-dev/realms/moh_applications/groups/pidp-management/variables.tf
@@ -1,0 +1,2 @@
+variable "USER-MANAGEMENT-SERVICE" {}
+variable "realm-management" {}

--- a/keycloak-dev/realms/moh_applications/groups/pidp-management/versions.tf
+++ b/keycloak-dev/realms/moh_applications/groups/pidp-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-dev/realms/moh_applications/groups/registries-access-team/main.tf
+++ b/keycloak-dev/realms/moh_applications/groups/registries-access-team/main.tf
@@ -1,0 +1,16 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "Registries Access Team"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.realm-management.ROLES["manage-users"].id,
+    var.realm-management.ROLES["query-clients"].id,
+    var.realm-management.ROLES["view-events"].id,
+    var.realm-management.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-dev/realms/moh_applications/groups/registries-access-team/output.tf
+++ b/keycloak-dev/realms/moh_applications/groups/registries-access-team/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-dev/realms/moh_applications/groups/registries-access-team/variables.tf
+++ b/keycloak-dev/realms/moh_applications/groups/registries-access-team/variables.tf
@@ -1,0 +1,1 @@
+variable "realm-management" {}

--- a/keycloak-dev/realms/moh_applications/groups/registries-access-team/versions.tf
+++ b/keycloak-dev/realms/moh_applications/groups/registries-access-team/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-dev/realms/moh_applications/groups/sat-access-management/main.tf
+++ b/keycloak-dev/realms/moh_applications/groups/sat-access-management/main.tf
@@ -1,0 +1,23 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "SAT-Access-Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-dbaac-portal"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-hibc-service-bc-portal"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-sfdc"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
+    var.realm-management.ROLES["query-clients"].id,
+    var.realm-management.ROLES["view-clients"].id
+  ]
+}

--- a/keycloak-dev/realms/moh_applications/groups/sat-access-management/output.tf
+++ b/keycloak-dev/realms/moh_applications/groups/sat-access-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-dev/realms/moh_applications/groups/sat-access-management/variables.tf
+++ b/keycloak-dev/realms/moh_applications/groups/sat-access-management/variables.tf
@@ -1,0 +1,2 @@
+variable "USER-MANAGEMENT-SERVICE" {}
+variable "realm-management" {}

--- a/keycloak-dev/realms/moh_applications/groups/sat-access-management/versions.tf
+++ b/keycloak-dev/realms/moh_applications/groups/sat-access-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-dev/realms/moh_applications/groups/webcaps-user-admin/main.tf
+++ b/keycloak-dev/realms/moh_applications/groups/webcaps-user-admin/main.tf
@@ -1,0 +1,22 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "WebCAPS User Admin"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
+    var.realm-management.ROLES["manage-users"].id,
+    var.realm-management.ROLES["query-clients"].id,
+    var.realm-management.ROLES["view-events"].id,
+    var.realm-management.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-dev/realms/moh_applications/groups/webcaps-user-admin/output.tf
+++ b/keycloak-dev/realms/moh_applications/groups/webcaps-user-admin/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-dev/realms/moh_applications/groups/webcaps-user-admin/variables.tf
+++ b/keycloak-dev/realms/moh_applications/groups/webcaps-user-admin/variables.tf
@@ -1,0 +1,2 @@
+variable "USER-MANAGEMENT-SERVICE" {}
+variable "realm-management" {}

--- a/keycloak-dev/realms/moh_applications/groups/webcaps-user-admin/versions.tf
+++ b/keycloak-dev/realms/moh_applications/groups/webcaps-user-admin/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Importing moh_applications groups to Keycloak on dev environment. Changes were imported beforehand, `terraform plan` should not show any config changes. 

### Context

Storing Keycloak configuration to utilize IaaC advantages.
 
### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
