### PR TITLE
HSPPCLIIP - Add client configuration to prod

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients.tf
+++ b/keycloak-prod/realms/moh_applications/clients.tf
@@ -67,6 +67,9 @@ module "HOOPC" {
 module "HSCIS" {
   source = "./clients/hscis"
 }
+module "HSPPCLIIP" {
+  source = "./clients/hsppcliip"
+}
 module "IEN" {
   source = "./clients/ien"
 }

--- a/keycloak-prod/realms/moh_applications/clients/hsppcliip/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hsppcliip/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "HSPPCLIIP"
   consent_required                    = false
-  description                         = "Prod configuration for HSIAR application"
+  description                         = "The Health System Performance Portal (HSPP) provides a panoramic analytical view of the health system in British Columbia across the four pillars of the Performance Management Framework"
   direct_access_grants_enabled        = false
   enabled                             = true
   frontchannel_logout_enabled         = false

--- a/keycloak-prod/realms/moh_applications/clients/hsppcliip/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hsppcliip/main.tf
@@ -1,0 +1,58 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "HSPPCLIIP"
+  consent_required                    = false
+  description                         = ""
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "HSPPCLIIP"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+    "https://hsppcliip.healthideas.gov.bc.ca/*",
+  ]
+  web_origins = [
+  ]
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper" {
+  add_to_access_token         = true
+  add_to_id_token             = true
+  claim_name                  = "roles"
+  claim_value_type            = "String"
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "HSPPCLIIP"
+  multivalued                 = true
+  name                        = "client roles"
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}
+
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "HSPP_ALL" = {
+      "name" = "HSPP_ALL"
+    },
+    "HSPP_OKR" = {
+      "name" = "HSPP_OKR"
+    },
+    "HSPP_HumanResource" = {
+      "name" = "HSPP_HumanResource"
+    },
+    "HI_Administrator" = {
+      "name" = "HI_Administrator"
+    },
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/hsppcliip/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hsppcliip/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "HSPPCLIIP"
   consent_required                    = false
-  description                         = ""
+  description                         = "Prod configuration for HSIAR application"
   direct_access_grants_enabled        = false
   enabled                             = true
   frontchannel_logout_enabled         = false

--- a/keycloak-prod/realms/moh_applications/clients/hsppcliip/outputs.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hsppcliip/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-prod/realms/moh_applications/clients/hsppcliip/versions.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hsppcliip/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Adding configuration for HSPPCLIIP to prod environment including:
Specified Redirect URL:
- https://hsppcliip.healthideas.gov.bc.ca/*

Requested roles:
- HSPP_ALL
- HSPP_OKR
- HSPP_HumanResource
- HI_Administrator

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
