### PR TITLE
import groups to test env

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
@@ -19,7 +19,10 @@ resource "keycloak_openid_client" "CLIENT" {
   standard_flow_enabled               = true
   use_refresh_tokens                  = false
   valid_redirect_uris = [
-    "https://cgi.com/"
+    "https://healthbc.lightning.force.com/*",
+    "https://healthbc.my.site.com/*",
+    "https://bchealthprovider.ca/*",
+    "https://www.bchealthprovider.ca/*"
   ]
   web_origins = [
   ]

--- a/keycloak-test/realms/moh_applications/groups.tf
+++ b/keycloak-test/realms/moh_applications/groups.tf
@@ -1,0 +1,107 @@
+module "CGI-DEVELOPER" {
+  source                  = "./groups/cgi-developer"
+  CGI-APPLICATION-SUPPORT = module.CGI-APPLICATION-SUPPORT
+  HSCIS                   = module.HSCIS
+  MANAGE-USERS            = module.MANAGE-USERS
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+  realm-management        = module.realm-management
+}
+
+module "CGI-MIDTIER" {
+  source                  = "./groups/cgi-midtier"
+  CGI-APPLICATION-SUPPORT = module.CGI-APPLICATION-SUPPORT
+  HEM                     = module.HEM
+  MANAGE-USERS            = module.MANAGE-USERS
+  realm-management        = module.realm-management
+}
+
+module "CGI-QA" {
+  source                  = "./groups/cgi-qa"
+  CGI-APPLICATION-SUPPORT = module.CGI-APPLICATION-SUPPORT
+  HEM                     = module.HEM
+  MANAGE-USERS            = module.MANAGE-USERS
+}
+
+module "CGI-REGISTRIES" {
+  source        = "./groups/cgi-registries"
+  HCIMWEB_HIAT1 = module.HCIMWEB_HIAT1
+  HCIMWEB_HIAT2 = module.HCIMWEB_HIAT2
+  HCIMWEB_HIAT3 = module.HCIMWEB_HIAT3
+  HCIMWEB_HS1   = module.HCIMWEB_HS1
+  HCIMWEB_HSIT  = module.HCIMWEB_HSIT
+  HCIMWEB_HUAT  = module.HCIMWEB_HUAT
+}
+
+module "EMCOD-ACCESS-TEAM" {
+  source                  = "./groups/emcod-access-team"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
+module "HIBC-ACCESS-MANAGEMENT" {
+  source                  = "./groups/hibc-access-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
+module "HSIAR-MANAGEMENT" {
+  source                  = "./groups/hsiar-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
+module "ITSB-ACCESS-TEAM" {
+  source                  = "./groups/itsb-access-team"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
+module "MAID-ACCESS-MANAGEMENT" {
+  source                  = "./groups/maid-access-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
+module "PIDP-MANAGEMENT" {
+  source                  = "./groups/pidp-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
+module "PLR-MANAGEMENT" {
+  source                  = "./groups/plr-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
+module "PRIME-MANAGEMENT" {
+  source                  = "./groups/prime-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
+module "PRP-USER-ADMIN" {
+  source                  = "./groups/prp-user-admin"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
+module "PRIMARY-CARE-ACCESS-TEAM" {
+  source                  = "./groups/primary-care-access-team"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
+module "REGISTRIES-ADMIN" {
+  source                  = "./groups/registries-admin"
+  HCIMWEB_HIAT1           = module.HCIMWEB_HIAT1
+  HCIMWEB_HIAT2           = module.HCIMWEB_HIAT2
+  HCIMWEB_HIAT3           = module.HCIMWEB_HIAT3
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
+module "REGISTRIES-CONNECTIONS-TEAM" {
+  source                  = "./groups/registries-connections-team"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
+module "TPL-MANAGEMENT" {
+  source                  = "./groups/tpl-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
+module "WEBCAPS-USER-ADMIN" {
+  source                  = "./groups/webcaps-user-admin"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+  realm-management        = module.realm-management
+}

--- a/keycloak-test/realms/moh_applications/groups/cgi-developer/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-developer/main.tf
@@ -1,0 +1,26 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "CGI Developer"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.CGI-APPLICATION-SUPPORT.REALM_ROLE.id,
+    var.HSCIS.ROLES["ADMIN"].id,
+    var.MANAGE-USERS.REALM_ROLE.id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-metrics"].id,
+    var.realm-management.ROLES["query-clients"].id,
+    var.realm-management.ROLES["query-groups"].id,
+    var.realm-management.ROLES["query-realms"].id,
+    var.realm-management.ROLES["query-users"].id,
+    var.realm-management.ROLES["view-authorization"].id,
+    var.realm-management.ROLES["view-clients"].id,
+    var.realm-management.ROLES["view-events"].id,
+    var.realm-management.ROLES["view-identity-providers"].id,
+    var.realm-management.ROLES["view-realm"].id,
+    var.realm-management.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/cgi-developer/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-developer/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/cgi-developer/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-developer/variables.tf
@@ -1,0 +1,5 @@
+variable "CGI-APPLICATION-SUPPORT" {}
+variable "HSCIS" {}
+variable "MANAGE-USERS" {}
+variable "USER-MANAGEMENT-SERVICE" {}
+variable "realm-management" {}

--- a/keycloak-test/realms/moh_applications/groups/cgi-developer/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-developer/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/cgi-midtier/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-midtier/main.tf
@@ -1,0 +1,32 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "CGI Midtier"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.CGI-APPLICATION-SUPPORT.REALM_ROLE.id,
+    var.HEM.ROLES["hem"].id,
+    var.MANAGE-USERS.REALM_ROLE.id,
+    var.realm-management.ROLES["create-client"].id,
+    var.realm-management.ROLES["manage-authorization"].id,
+    var.realm-management.ROLES["manage-clients"].id,
+    var.realm-management.ROLES["manage-events"].id,
+    var.realm-management.ROLES["manage-identity-providers"].id,
+    var.realm-management.ROLES["manage-realm"].id,
+    var.realm-management.ROLES["manage-users"].id,
+    var.realm-management.ROLES["query-clients"].id,
+    var.realm-management.ROLES["query-groups"].id,
+    var.realm-management.ROLES["query-realms"].id,
+    var.realm-management.ROLES["query-users"].id,
+    var.realm-management.ROLES["view-authorization"].id,
+    var.realm-management.ROLES["view-clients"].id,
+    var.realm-management.ROLES["view-events"].id,
+    var.realm-management.ROLES["view-identity-providers"].id,
+    var.realm-management.ROLES["view-realm"].id,
+    var.realm-management.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/cgi-midtier/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-midtier/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/cgi-midtier/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-midtier/variables.tf
@@ -1,0 +1,4 @@
+variable "CGI-APPLICATION-SUPPORT" {}
+variable "HEM" {}
+variable "MANAGE-USERS" {}
+variable "realm-management" {}

--- a/keycloak-test/realms/moh_applications/groups/cgi-midtier/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-midtier/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/cgi-qa/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-qa/main.tf
@@ -1,0 +1,15 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "CGI QA"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.CGI-APPLICATION-SUPPORT.REALM_ROLE.id,
+    var.HEM.ROLES["hem"].id,
+    var.MANAGE-USERS.REALM_ROLE.id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/cgi-qa/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-qa/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/cgi-qa/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-qa/variables.tf
@@ -1,0 +1,3 @@
+variable "CGI-APPLICATION-SUPPORT" {}
+variable "HEM" {}
+variable "MANAGE-USERS" {}

--- a/keycloak-test/realms/moh_applications/groups/cgi-qa/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-qa/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/cgi-registries/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-registries/main.tf
@@ -1,0 +1,18 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "CGI Registries"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.HCIMWEB_HIAT1.ROLES["REG_ADMIN_HCIM"].id,
+    var.HCIMWEB_HIAT2.ROLES["REG_ADMIN_HCIM"].id,
+    var.HCIMWEB_HIAT3.ROLES["REG_ADMIN_HCIM"].id,
+    var.HCIMWEB_HS1.ROLES["REG_ADMIN_HCIM"].id,
+    var.HCIMWEB_HSIT.ROLES["REG_ADMIN_HCIM"].id,
+    var.HCIMWEB_HUAT.ROLES["REG_ADMIN_HCIM"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/cgi-registries/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-registries/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/cgi-registries/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-registries/variables.tf
@@ -1,0 +1,6 @@
+variable "HCIMWEB_HIAT1" {}
+variable "HCIMWEB_HIAT2" {}
+variable "HCIMWEB_HIAT3" {}
+variable "HCIMWEB_HS1" {}
+variable "HCIMWEB_HSIT" {}
+variable "HCIMWEB_HUAT" {}

--- a/keycloak-test/realms/moh_applications/groups/cgi-registries/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-registries/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/emcod-access-team/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/emcod-access-team/main.tf
@@ -1,0 +1,21 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "EMCOD Access Team"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-emcod"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/emcod-access-team/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/emcod-access-team/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/emcod-access-team/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/emcod-access-team/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/emcod-access-team/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/emcod-access-team/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/hibc-access-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/hibc-access-management/main.tf
@@ -1,0 +1,22 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "HIBC Access Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-org"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-mspdirect-service-uat"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/hibc-access-management/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/hibc-access-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/hibc-access-management/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/hibc-access-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/hibc-access-management/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/hibc-access-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/hsiar-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/hsiar-management/main.tf
@@ -1,0 +1,17 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "HSIAR Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hsiar"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/hsiar-management/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/hsiar-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/hsiar-management/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/hsiar-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/hsiar-management/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/hsiar-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/itsb-access-team/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/itsb-access-team/main.tf
@@ -1,0 +1,37 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "ITSB Access Team"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-org"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl_stg"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-fmdb"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-gis"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hamis"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hscis"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt_stg"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-dbaac-portal"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-hibc-service-bc-portal"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-sfdc"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sfds"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-swt"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-swt_stg"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-tap"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/itsb-access-team/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/itsb-access-team/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/itsb-access-team/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/itsb-access-team/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/itsb-access-team/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/itsb-access-team/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/maid-access-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/maid-access-management/main.tf
@@ -1,0 +1,18 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "MAID Access Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-maid"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/maid-access-management/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/maid-access-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/maid-access-management/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/maid-access-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/maid-access-management/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/maid-access-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/pidp-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/pidp-management/main.tf
@@ -1,0 +1,24 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "PIdP Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-dmft-webapp"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-gis"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_huat"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-licence-status"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pidp-service"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sat-eforms"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/pidp-management/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/pidp-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/pidp-management/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/pidp-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/pidp-management/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/pidp-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/plr-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/plr-management/main.tf
@@ -1,0 +1,26 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "PLR Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_conf"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_flvr"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_iat"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_rev"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_sit"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_stg"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_uat"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/plr-management/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/plr-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/plr-management/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/plr-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/plr-management/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/plr-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/primary-care-access-team/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/primary-care-access-team/main.tf
@@ -1,0 +1,19 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "Primary Care Access Team"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/primary-care-access-team/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/primary-care-access-team/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/primary-care-access-team/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/primary-care-access-team/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/primary-care-access-team/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/primary-care-access-team/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/prime-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/prime-management/main.tf
@@ -1,0 +1,21 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "PRIME Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-prime-application-local"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-prime-application-test"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/prime-management/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/prime-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/prime-management/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/prime-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/prime-management/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/prime-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/prp-user-admin/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/prp-user-admin/main.tf
@@ -1,0 +1,21 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "PRP User Admin"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-prp-service"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/prp-user-admin/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/prp-user-admin/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/prp-user-admin/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/prp-user-admin/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/prp-user-admin/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/prp-user-admin/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/registries-admin/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/registries-admin/main.tf
@@ -1,0 +1,29 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "Registries Admin"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.HCIMWEB_HIAT1.ROLES["REG_ADMIN_HCIM"].id,
+    var.HCIMWEB_HIAT2.ROLES["REG_ADMIN_HCIM"].id,
+    var.HCIMWEB_HIAT3.ROLES["REG_ADMIN_HCIM"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_conf"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_iat"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_rev"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_sit"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_stg"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_uat"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/registries-admin/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/registries-admin/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/registries-admin/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/registries-admin/variables.tf
@@ -1,0 +1,4 @@
+variable "HCIMWEB_HIAT1" {}
+variable "HCIMWEB_HIAT2" {}
+variable "HCIMWEB_HIAT3" {}
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/registries-admin/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/registries-admin/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/registries-connections-team/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/registries-connections-team/main.tf
@@ -1,0 +1,31 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "Registries Connections Team"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-gis"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_hiat1"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_hiat2"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_hiat3"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_hsit"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_huat"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_conf"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_iat"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_rev"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_sit"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_stg"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_uat"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/registries-connections-team/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/registries-connections-team/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/registries-connections-team/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/registries-connections-team/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/registries-connections-team/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/registries-connections-team/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/tpl-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/tpl-management/main.tf
@@ -1,0 +1,20 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "TPL Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-tpl"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/tpl-management/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/tpl-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/tpl-management/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/tpl-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/tpl-management/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/tpl-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/groups/webcaps-user-admin/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/webcaps-user-admin/main.tf
@@ -1,0 +1,24 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "WebCAPS User Admin"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-webcaps"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
+    var.realm-management.ROLES["manage-users"].id,
+    var.realm-management.ROLES["query-clients"].id,
+    var.realm-management.ROLES["view-events"].id,
+    var.realm-management.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/webcaps-user-admin/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/webcaps-user-admin/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/webcaps-user-admin/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/webcaps-user-admin/variables.tf
@@ -1,0 +1,2 @@
+variable "USER-MANAGEMENT-SERVICE" {}
+variable "realm-management" {}

--- a/keycloak-test/realms/moh_applications/groups/webcaps-user-admin/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/webcaps-user-admin/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Import groups from Keycloak test to terraform. Update redirect URLs for PRIMARY-CARE prod client.

### Context

Plan should show only URL changes. The group resources were imported. 
 
### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
