### PR TITLE
add redirect url for primary-care on prod

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
@@ -22,7 +22,8 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://healthbc.lightning.force.com/*",
     "https://healthbc.my.site.com/*",
     "https://bchealthprovider.ca/*",
-    "https://www.bchealthprovider.ca/*"
+    "https://www.bchealthprovider.ca/*",
+    "https://healthbc.my.salesforce.com/*",
   ]
   web_origins = [
   ]


### PR DESCRIPTION
### Changes being made

Adding URL to PRIMARY-CARE client on prod env.
 
### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
