### PR TITLE
Cleaning up BCER-CP Test client

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
@@ -25,8 +25,6 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://localhost:3001/*",
     "https://bcer-dev.hlth.gov.bc.ca/portal/*",
     "https://bcer-test.hlth.gov.bc.ca/portal/*",
-    "https://d2ys4dsq8xqjer.cloudfront.net/portal/*",
-    "https://d4j0vravf4z7q.cloudfront.net/portal/*",
   ]
   web_origins = [
     "+",


### PR DESCRIPTION
### Changes being made

Removing deprecated CloudFront Request URIs.

### Context

BCER figured it's shit out.
 
### Quality Check

- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^1]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)