### PR TITLE
add IDP mapper for PRIMARY-CARE and update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ What is the context for those changes? For example: particular role needs to be 
 - [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
 - [ ] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
 - [ ] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
-- [ ] Client module and all references are defined in main.tf in realm root folder.
+- [ ] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
 - [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
 - [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
 

--- a/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
@@ -101,13 +101,14 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "cpn" {
 }
 
 resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
-  add_to_id_token  = false
-  claim_name       = "identity_provider"
-  claim_value_type = "String"
-  client_id        = keycloak_openid_client.CLIENT.id
-  name             = "IDP"
-  realm_id         = keycloak_openid_client.CLIENT.realm_id
-  session_note     = "identity_provider"
+  add_to_id_token     = true
+  add_to_access_token = true
+  claim_name          = "identity_provider"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "IDP"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+  session_note        = "identity_provider"
 }
 
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {

--- a/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
@@ -100,6 +100,16 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "cpn" {
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
+  add_to_id_token  = false
+  claim_name       = "identity_provider"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "IDP"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "identity_provider"
+}
+
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
@@ -112,6 +112,16 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "cpn" {
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
+  add_to_id_token  = false
+  claim_name       = "identity_provider"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "IDP"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "identity_provider"
+}
+
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
@@ -113,13 +113,14 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "cpn" {
 }
 
 resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
-  add_to_id_token  = false
-  claim_name       = "identity_provider"
-  claim_value_type = "String"
-  client_id        = keycloak_openid_client.CLIENT.id
-  name             = "IDP"
-  realm_id         = keycloak_openid_client.CLIENT.realm_id
-  session_note     = "identity_provider"
+  add_to_id_token     = true
+  add_to_access_token = true
+  claim_name          = "identity_provider"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "IDP"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+  session_note        = "identity_provider"
 }
 
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {


### PR DESCRIPTION
### Changes being made

Adding IDP mappers for PRIMARY-CARE in test and prod.

### Context

IDP value needs to be accessible through token sent from Keycloak.
 
### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
