### PR TITLE
Adding FMDB Prod Redirect URI for AWS migration

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/fmdb/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/fmdb/main.tf
@@ -22,6 +22,7 @@ module "payara-client" {
   use_refresh_tokens       = false
   valid_redirect_uris = [
     "https://fmdb.hlth.gov.bc.ca/*",
+    "https://fmdb.ynr9ed-prod.nimbus.cloud.gov.bc.ca/*",
     "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi*",
   ]
 }


### PR DESCRIPTION
### Changes being made

Adding AWS Redirect URI.

### Context

FMDB Prod will eventually cutover to AWS and the vanity url (fmdb.hlth.gov.bc.ca) won't be in use for go-live.
 
### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
