### PR TITLE
Added HCIM_LRA client.

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -377,6 +377,9 @@ module "HCIM_IHA" {
 module "HCIM_LCTZ" {
   source = "./clients/hcim_lctz"
 }
+module "HCIM_LRA" {
+  source = "./clients/hcim_lra"
+}
 module "HCIM_MOH_CRS" {
   source = "./clients/hcim_moh_crs"
 }

--- a/keycloak-test/realms/moh_applications/clients/hcim_lra/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcim_lra/main.tf
@@ -1,0 +1,46 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "HCIM_LRA"
+  consent_required                    = false
+  description                         = "Healthcare Client Identity Management"
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = ""
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = true
+  standard_flow_enabled               = false
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+module "service-account-roles" {
+  source                  = "../../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {}
+}
+resource "keycloak_openid_hardcoded_claim_protocol_mapper" "hcim_org" {
+  add_to_access_token = true
+  add_to_id_token     = true
+  add_to_userinfo     = true
+  claim_name          = "hcim_org"
+  claim_value         = "organization/LRA"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "hcim_org"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-test/realms/moh_applications/clients/hcim_lra/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcim_lra/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/hcim_lra/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcim_lra/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Adding HCIM_LRA client to Test environment.

### Context

Request from Kim Glidden. Modelled after HCIM_VIHA.
 
### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [x] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
