### PR TITLE
create primary-care-access group on prod

### DIFF
--- a/keycloak-prod/realms/moh_applications/groups.tf
+++ b/keycloak-prod/realms/moh_applications/groups.tf
@@ -60,6 +60,11 @@ module "PIDP-MANAGEMENT" {
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
 }
 
+module "PRIMARY-CARE-ACCESS-TEAM" {
+  source                  = "./groups/primary-care-access-team"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
 module "PRIME-MANAGEMENT" {
   source                  = "./groups/prime-management"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE

--- a/keycloak-prod/realms/moh_applications/groups/primary-care-access-team/main.tf
+++ b/keycloak-prod/realms/moh_applications/groups/primary-care-access-team/main.tf
@@ -15,6 +15,6 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
     var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-primary-care"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
   ]
 }

--- a/keycloak-prod/realms/moh_applications/groups/primary-care-access-team/output.tf
+++ b/keycloak-prod/realms/moh_applications/groups/primary-care-access-team/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-prod/realms/moh_applications/groups/primary-care-access-team/variables.tf
+++ b/keycloak-prod/realms/moh_applications/groups/primary-care-access-team/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-prod/realms/moh_applications/groups/primary-care-access-team/versions.tf
+++ b/keycloak-prod/realms/moh_applications/groups/primary-care-access-team/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Updated PRIMARY-CARE group on test and created one on prod environment.

### Context

The changes will allow PRIMARY-CARE team to assign application roles through UMC.
 
### Quality Check

- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
