### PR TITLE
Added PLR_REV/CONSUMER role to allow access to PLR Review environment.

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -166,8 +166,8 @@ module "PLR-PRIMARY-CARE" {
   PLR_STG  = module.PLR_STG
 }
 module "PLR-PRP" {
-  source = "./clients/plr-prp"
-  PLR_REV  = module.PLR_REV
+  source  = "./clients/plr-prp"
+  PLR_REV = module.PLR_REV
 }
 module "PLR-QA-CONSUMER" {
   source   = "./clients/plr-qa-consumer"

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -167,6 +167,7 @@ module "PLR-PRIMARY-CARE" {
 }
 module "PLR-PRP" {
   source = "./clients/plr-prp"
+  PLR_REV  = module.PLR_REV
 }
 module "PLR-QA-CONSUMER" {
   source   = "./clients/plr-qa-consumer"

--- a/keycloak-test/realms/moh_applications/clients/plr-prp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-prp/main.tf
@@ -34,3 +34,26 @@ resource "keycloak_openid_hardcoded_claim_protocol_mapper" "orgId" {
   name                = "orgId"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
+module "service-account-roles" {
+  source                  = "../../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {
+    "PLR_REV/CONSUMER" = {
+      "client_id" = var.PLR_REV.CLIENT.id,
+      "role_id"   = "CONSUMER"
+    }
+  }
+}
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "PLR_REV/CONSUMER"  = var.PLR_REV.ROLES["CONSUMER"].id
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/plr-prp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-prp/main.tf
@@ -54,6 +54,6 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "PLR_REV/CONSUMER"  = var.PLR_REV.ROLES["CONSUMER"].id
+    "PLR_REV/CONSUMER" = var.PLR_REV.ROLES["CONSUMER"].id
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/plr-prp/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-prp/variables.tf
@@ -1,0 +1,1 @@
+variable "PLR_REV" {}


### PR DESCRIPTION
### Changes being made

Added PLR_REV/CONSUMER scope mappings/role to PLR-PRP allow access to PLR Review environment.

### Context

The PRP application needs to query the PLR review environment via the PLR-PRP service account.
 
### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [x] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
