### PR TITLE
add redirect urls form primary-care on test

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
@@ -34,7 +34,10 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://healthbc--hlthbcuat.sandbox.my.salesforce.com/*",
     "https://healthbc--hlthbcuat.sandbox.my.site.com/*",
     "https://healthbc--hlthbcdevn.sandbox.my.salesforce.com/*",
-    "https://healthbc--hlthbcdevn.sandbox.my.site.com/*"
+    "https://healthbc--hlthbcdevn.sandbox.my.site.com/*",
+    "https://healthbc--hlthbcprvx.sandbox.my.salesforce.com/*",
+    "https://healthbc--hlthbcprvx.sandbox.my.site.com/*"
+
 
   ]
   web_origins = [


### PR DESCRIPTION
### Changes being made

Adding redirect URLs for PRIMARY-CARE client on test

### Context

AM Team mailbox request.
 
### Quality Check

- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
