### PR TITLE
Adding Prod HSPP URL for their surprise cutover

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
@@ -2,7 +2,7 @@ resource "keycloak_openid_client" "CLIENT" {
   access_token_lifespan               = ""
   access_type                         = "CONFIDENTIAL"
   backchannel_logout_session_required = true
-  base_url                            = ""
+  base_url                            = "https://hspp.hlth.gov.bc.ca"
   client_authenticator_type           = "client-secret"
   client_id                           = "HSPP"
   consent_required                    = false
@@ -19,6 +19,7 @@ resource "keycloak_openid_client" "CLIENT" {
   standard_flow_enabled               = true
   use_refresh_tokens                  = true
   valid_redirect_uris = [
+    "https://hspp.hlth.gov.bc.ca/*",
     "https://hsppcliip.healthideas.gov.bc.ca/*",
   ]
   web_origins = [


### PR DESCRIPTION
### Changes being made

Add https://hspp.hlth.gov.bc.ca as valid redirect URI for HSPP Prod.

### Context

HSPP cutover in Prod without letting us know ahead of time, so this is an urgent change (made manually).
 
### Quality Check

- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
