### PR TITLE
create hspp group on prod env

### DIFF
--- a/keycloak-prod/realms/moh_applications/groups.tf
+++ b/keycloak-prod/realms/moh_applications/groups.tf
@@ -39,6 +39,11 @@ module "HIBC-MSP-DIRECT" {
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
 }
 
+module "HSPP-MANAGEMENT" {
+  source                  = "./groups/hspp-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
 module "ITSB-ACCESS-TEAM" {
   source                  = "./groups/itsb-access-team"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE

--- a/keycloak-prod/realms/moh_applications/groups/hspp-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/groups/hspp-management/main.tf
@@ -1,0 +1,19 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "HSPP Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hspp"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-prod/realms/moh_applications/groups/hspp-management/output.tf
+++ b/keycloak-prod/realms/moh_applications/groups/hspp-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-prod/realms/moh_applications/groups/hspp-management/variables.tf
+++ b/keycloak-prod/realms/moh_applications/groups/hspp-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-prod/realms/moh_applications/groups/hspp-management/versions.tf
+++ b/keycloak-prod/realms/moh_applications/groups/hspp-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Create HSPP management group in Prod env.

### Context

This will allow HSPP admins to manage user roles through UMC.
 
### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
