### PR TITLE
Adding HTTPS localhost valid redirect uri to HSPP Test as per Gary Sun

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -20,6 +20,7 @@ resource "keycloak_openid_client" "CLIENT" {
   use_refresh_tokens                  = true
   valid_redirect_uris = [
     "http://localhost:*",
+    "https://localhost:*",
     "https://hsppstg.hlth.gov.bc.ca/*",
   ]
   web_origins = [


### PR DESCRIPTION
### Changes being made

Adding HTTPS localhost to HSPP Test client to match HSIAR Test functionality.

### Context

Adding new Valid Redirect URI to HSPP Test as per Gary's request.
 
### Quality Check

- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
