### PR TITLE
Adding new roles to HSPP Prod as per Joyce's request

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
@@ -71,5 +71,14 @@ module "client-roles" {
     "HSPP_ReportSection_All" = {
       "name" = "HSPP_ReportSection_All"
     },
+    "HSPP_ReportProgram_Invictus" = {
+      "name" = "HSPP_ReportProgram_Invictus"
+    },
+    "HSPP_ReportSection_Invictus" = {
+      "name" = "HSPP_ReportSection_Invictus"
+    },
+    "HSPP_Report_Invictus" = {
+      "name" = "HSPP_Report_Invictus"
+    },
   }
 }


### PR DESCRIPTION
### Changes being made

Adding the following roles to HSPP Prod

- HSPP_ReportProgram_Invictus
- HSPP_ReportSection_Invictus
- HSPP_Report_Invictus

### Context

Adding new roles to HSPP Prod as per Joyce's request.
 
### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
