### PR TITLE
Create PLR-LRA client to provide access to PLR APIs for LRA

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -156,8 +156,8 @@ module "PIDP-WEBAPP" {
   PIDP-SERVICE = module.PIDP-SERVICE
 }
 module "PLR-LRA" {
-  source   = "./clients/plr-lra"
-  PLR_REV  = module.PLR_REV
+  source  = "./clients/plr-lra"
+  PLR_REV = module.PLR_REV
 }
 module "PLR-PRIMARY-CARE" {
   source   = "./clients/plr-primary-care"

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -155,6 +155,10 @@ module "PIDP-WEBAPP" {
   account      = module.account
   PIDP-SERVICE = module.PIDP-SERVICE
 }
+module "PLR-LRA" {
+  source   = "./clients/plr-lra"
+  PLR_REV  = module.PLR_REV
+}
 module "PLR-PRIMARY-CARE" {
   source   = "./clients/plr-primary-care"
   PLR_IAT  = module.PLR_IAT

--- a/keycloak-test/realms/moh_applications/clients/plr-lra/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-lra/main.tf
@@ -4,9 +4,9 @@ resource "keycloak_openid_client" "CLIENT" {
   backchannel_logout_session_required = true
   base_url                            = ""
   client_authenticator_type           = "client-secret"
-  client_id                           = "PLR-QA-MOH-APPROVER"
+  client_id                           = "PLR-LRA"
   consent_required                    = false
-  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR MOH_APPROVER role"
+  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR CONSUMER role"
   enabled                             = true
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
@@ -69,25 +69,9 @@ module "service-account-roles" {
     "default-roles-moh_applications" = "default-roles-moh_applications",
   }
   client_roles = {
-    "PLR_IAT/MOH_APPROVER" = {
-      "client_id" = var.PLR_IAT.CLIENT.id,
-      "role_id"   = "MOH_APPROVER"
-    }
-    "PLR_UAT/MOH_APPROVER" = {
-      "client_id" = var.PLR_UAT.CLIENT.id,
-      "role_id"   = "MOH_APPROVER"
-    }
-    "PLR_CONF/MOH_APPROVER" = {
-      "client_id" = var.PLR_CONF.CLIENT.id,
-      "role_id"   = "MOH_APPROVER"
-    }
-    "PLR_SIT/MOH_APPROVER" = {
-      "client_id" = var.PLR_SIT.CLIENT.id,
-      "role_id"   = "MOH_APPROVER"
-    }
-    "PLR_REV/MOH_APPROVER" = {
+    "PLR_REV/CONSUMER" = {
       "client_id" = var.PLR_REV.CLIENT.id,
-      "role_id"   = "MOH_APPROVER"
+      "role_id"   = "CONSUMER"
     }
   }
 }
@@ -96,10 +80,6 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "PLR_IAT/MOH_APPROVER"  = var.PLR_IAT.ROLES["MOH_APPROVER"].id
-    "PLR_UAT/MOH_APPROVER"  = var.PLR_UAT.ROLES["MOH_APPROVER"].id
-    "PLR_CONF/MOH_APPROVER" = var.PLR_CONF.ROLES["MOH_APPROVER"].id
-    "PLR_SIT/MOH_APPROVER"  = var.PLR_SIT.ROLES["MOH_APPROVER"].id
-    "PLR_REV/MOH_APPROVER"  = var.PLR_REV.ROLES["MOH_APPROVER"].id
+    "PLR_REV/CONSUMER"  = var.PLR_REV.ROLES["CONSUMER"].id
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/plr-lra/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-lra/main.tf
@@ -80,6 +80,6 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "PLR_REV/CONSUMER"  = var.PLR_REV.ROLES["CONSUMER"].id
+    "PLR_REV/CONSUMER" = var.PLR_REV.ROLES["CONSUMER"].id
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/plr-lra/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-lra/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/plr-lra/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-lra/variables.tf
@@ -1,0 +1,1 @@
+variable "PLR_REV" {}

--- a/keycloak-test/realms/moh_applications/clients/plr-lra/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-lra/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/plr-qa-consumer/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-qa-consumer/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "PLR-QA-CONSUMER"
   consent_required                    = false
-  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate accces tokens for the internal PLR QA team with the PLR CONSUMER role"
+  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR CONSUMER role"
   enabled                             = true
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false

--- a/keycloak-test/realms/moh_applications/clients/plr-qa-dsr-user/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-qa-dsr-user/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "PLR-QA-DSR-USER"
   consent_required                    = false
-  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate accces tokens for the internal PLR QA team with the PLR DSR_USER role"
+  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR DSR_USER role"
   enabled                             = true
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false

--- a/keycloak-test/realms/moh_applications/clients/plr-qa-primary-source/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-qa-primary-source/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "PLR-QA-PRIMARY-SOURCE"
   consent_required                    = false
-  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate accces tokens for the internal PLR QA team with the PLR PRIMARY_SOURCE role"
+  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR PRIMARY_SOURCE role"
   enabled                             = true
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false

--- a/keycloak-test/realms/moh_applications/clients/plr-qa-regadmin/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-qa-regadmin/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "PLR-QA-REGADMIN"
   consent_required                    = false
-  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate accces tokens for the internal PLR QA team with the PLR REG_ADMIN role"
+  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR REG_ADMIN role"
   enabled                             = true
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false

--- a/keycloak-test/realms/moh_applications/clients/plr-qa-secondary-source/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-qa-secondary-source/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "PLR-QA-SECONDARY-SOURCE"
   consent_required                    = false
-  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate accces tokens for the internal PLR QA team with the PLR SECONDARY_SOURCE role"
+  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR SECONDARY_SOURCE role"
   enabled                             = true
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false


### PR DESCRIPTION
### Changes being made

Create PLR-LRA client to provide access to PLR APIs for LRA. Fix a description field typo in the other PLR API clients.

### Context

Kim Glidden is requesting this client for LRA to access PLR APIs on behalf of LRA.
 
### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
