### PR TITLE
Removed unneeded mappers.

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/plr-lra/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-lra/main.tf
@@ -33,33 +33,6 @@ resource "keycloak_openid_hardcoded_claim_protocol_mapper" "orgId" {
   name                = "orgId"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
-resource "keycloak_openid_user_session_note_protocol_mapper" "Client-Host" {
-  add_to_id_token  = true
-  claim_name       = "clientHost"
-  claim_value_type = "String"
-  client_id        = keycloak_openid_client.CLIENT.id
-  name             = "Client Host"
-  realm_id         = keycloak_openid_client.CLIENT.realm_id
-  session_note     = "clientHost"
-}
-resource "keycloak_openid_user_session_note_protocol_mapper" "Client-ID" {
-  add_to_id_token  = true
-  claim_name       = "clientId"
-  claim_value_type = "String"
-  client_id        = keycloak_openid_client.CLIENT.id
-  name             = "Client ID"
-  realm_id         = keycloak_openid_client.CLIENT.realm_id
-  session_note     = "clientId"
-}
-resource "keycloak_openid_user_session_note_protocol_mapper" "Client-IP-Address" {
-  add_to_id_token  = true
-  claim_name       = "clientAddress"
-  claim_value_type = "String"
-  client_id        = keycloak_openid_client.CLIENT.id
-  name             = "Client IP Address"
-  realm_id         = keycloak_openid_client.CLIENT.realm_id
-  session_note     = "clientAddress"
-}
 module "service-account-roles" {
   source                  = "../../../../../modules/service-account-roles"
   realm_id                = keycloak_openid_client.CLIENT.realm_id

--- a/keycloak-test/realms/moh_applications/clients/plr-lra/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-lra/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "PLR-LRA"
   consent_required                    = false
-  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR CONSUMER role"
+  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources."
   enabled                             = true
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false

--- a/keycloak-test/realms/moh_applications/clients/plr-qa-consumer/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-qa-consumer/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "PLR-QA-CONSUMER"
   consent_required                    = false
-  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR CONSUMER role"
+  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR CONSUMER role."
   enabled                             = true
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false

--- a/keycloak-test/realms/moh_applications/clients/plr-qa-dsr-user/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-qa-dsr-user/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "PLR-QA-DSR-USER"
   consent_required                    = false
-  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR DSR_USER role"
+  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR DSR_USER role."
   enabled                             = true
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false

--- a/keycloak-test/realms/moh_applications/clients/plr-qa-moh-approver/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-qa-moh-approver/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "PLR-QA-MOH-APPROVER"
   consent_required                    = false
-  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR MOH_APPROVER role"
+  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR MOH_APPROVER role."
   enabled                             = true
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false

--- a/keycloak-test/realms/moh_applications/clients/plr-qa-primary-source/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-qa-primary-source/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "PLR-QA-PRIMARY-SOURCE"
   consent_required                    = false
-  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR PRIMARY_SOURCE role"
+  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR PRIMARY_SOURCE role."
   enabled                             = true
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false

--- a/keycloak-test/realms/moh_applications/clients/plr-qa-regadmin/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-qa-regadmin/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "PLR-QA-REGADMIN"
   consent_required                    = false
-  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR REG_ADMIN role"
+  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR REG_ADMIN role."
   enabled                             = true
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false

--- a/keycloak-test/realms/moh_applications/clients/plr-qa-secondary-source/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-qa-secondary-source/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "PLR-QA-SECONDARY-SOURCE"
   consent_required                    = false
-  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR SECONDARY_SOURCE role"
+  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR QA team with the PLR SECONDARY_SOURCE role."
   enabled                             = true
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false


### PR DESCRIPTION
### Changes being made

Removing unneeded protocol mappers. Created by Keycloak by default for service accounts. Not needed. Caused the Terraform apply to fail because the mappers already exist by default when service accounts are enabled.

### Context

PLR-API access for LRA requested by Kim Glidden.
 
### Quality Check

Same as last PR.