### PR TITLE
create hspp roles on test and prod and add url for bcer-cp

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
@@ -80,5 +80,17 @@ module "client-roles" {
     "HSPP_Report_Invictus" = {
       "name" = "HSPP_Report_Invictus"
     },
+    "HSPP_Restricted_ACFT" = {
+      "name" = "HSPP_Restricted_ACFT"
+    },
+    "HSPP_Restricted_PCR" = {
+      "name" = "HSPP_Restricted_PCR"
+    },
+    "HSPP_Restricted_UPCC" = {
+      "name" = "HSPP_Restricted_UPCC"
+    },
+    "HSPP_Restricted_PEP" = {
+      "name" = "HSPP_Restricted_PEP"
+    },
   }
 }

--- a/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
@@ -86,11 +86,11 @@ module "client-roles" {
     "HSPP_Restricted_PCR" = {
       "name" = "HSPP_Restricted_PCR"
     },
-    "HSPP_Restricted_UPCC" = {
-      "name" = "HSPP_Restricted_UPCC"
-    },
     "HSPP_Restricted_PEP" = {
       "name" = "HSPP_Restricted_PEP"
+    },
+    "HSPP_Restricted_UPCC" = {
+      "name" = "HSPP_Restricted_UPCC"
     },
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
@@ -25,6 +25,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://localhost:3001/*",
     "https://bcer-dev.hlth.gov.bc.ca/portal/*",
     "https://bcer-test.hlth.gov.bc.ca/portal/*",
+    "https://d3naoa5ica8tt3.cloudfront.net/portal/*",
   ]
   web_origins = [
     "+",

--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -87,11 +87,11 @@ module "client-roles" {
     "HSPP_Restricted_PCR" = {
       "name" = "HSPP_Restricted_PCR"
     },
-    "HSPP_Restricted_UPCC" = {
-      "name" = "HSPP_Restricted_UPCC"
-    },
     "HSPP_Restricted_PEP" = {
       "name" = "HSPP_Restricted_PEP"
+    },
+    "HSPP_Restricted_UPCC" = {
+      "name" = "HSPP_Restricted_UPCC"
     },
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -81,5 +81,17 @@ module "client-roles" {
     "HSPP_Report_Invictus" = {
       "name" = "HSPP_Report_Invictus"
     },
+    "HSPP_Restricted_ACFT" = {
+      "name" = "HSPP_Restricted_ACFT"
+    },
+    "HSPP_Restricted_PCR" = {
+      "name" = "HSPP_Restricted_PCR"
+    },
+    "HSPP_Restricted_UPCC" = {
+      "name" = "HSPP_Restricted_UPCC"
+    },
+    "HSPP_Restricted_PEP" = {
+      "name" = "HSPP_Restricted_PEP"
+    },
   }
 }


### PR DESCRIPTION
### Changes being made

Adding HSPP roles to Test and Prod. Adding redirect URL to BCER-CP on Test
### Context

HSPP - team mailbox request. BCER-CP url  was previously added through admin console.

### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.
