### PR TITLE
add birthdate mapper to dmft and prime

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/dmft-webapp/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/dmft-webapp/main.tf
@@ -42,6 +42,14 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_attribute_protocol_mapper" "birthdate" {
+  claim_name     = "birthdate"
+  client_id      = keycloak_openid_client.CLIENT.id
+  name           = "birthdate"
+  user_attribute = "birthdate"
+  realm_id       = keycloak_openid_client.CLIENT.realm_id
+}
+
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-dev/realms/moh_applications/clients/prime-webapp-enrollment/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/prime-webapp-enrollment/main.tf
@@ -35,6 +35,13 @@ resource "keycloak_openid_audience_protocol_mapper" "Prime-Audience-Mapper" {
   name                     = "Prime Audience Mapper"
   realm_id                 = keycloak_openid_client.CLIENT.realm_id
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "birthdate" {
+  claim_name     = "birthdate"
+  client_id      = keycloak_openid_client.CLIENT.id
+  name           = "birthdate"
+  user_attribute = "birthdate"
+  realm_id       = keycloak_openid_client.CLIENT.realm_id
+}
 module "scope-mappings" {
   source    = "../../../../../modules/scope-mappings"
   realm_id  = keycloak_openid_client.CLIENT.realm_id

--- a/keycloak-test/realms/moh_applications/clients/dmft-webapp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/dmft-webapp/main.tf
@@ -44,6 +44,14 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_attribute_protocol_mapper" "birthdate" {
+  claim_name     = "birthdate"
+  client_id      = keycloak_openid_client.CLIENT.id
+  name           = "birthdate"
+  user_attribute = "birthdate"
+  realm_id       = keycloak_openid_client.CLIENT.realm_id
+}
+
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-test/realms/moh_applications/clients/prime-application-dev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prime-application-dev/main.tf
@@ -25,3 +25,11 @@ resource "keycloak_openid_client" "CLIENT" {
     "*",
   ]
 }
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "birthdate" {
+  claim_name     = "birthdate"
+  client_id      = keycloak_openid_client.CLIENT.id
+  name           = "birthdate"
+  user_attribute = "birthdate"
+  realm_id       = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-test/realms/moh_applications/clients/prime-application-local/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prime-application-local/main.tf
@@ -71,6 +71,14 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "identity_assurance_le
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_attribute_protocol_mapper" "birthdate" {
+  claim_name     = "birthdate"
+  client_id      = keycloak_openid_client.CLIENT.id
+  name           = "birthdate"
+  user_attribute = "birthdate"
+  realm_id       = keycloak_openid_client.CLIENT.realm_id
+}
+
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-test/realms/moh_applications/clients/prime-application-test/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prime-application-test/main.tf
@@ -71,6 +71,14 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "identity_assurance_le
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_attribute_protocol_mapper" "birthdate" {
+  claim_name     = "birthdate"
+  client_id      = keycloak_openid_client.CLIENT.id
+  name           = "birthdate"
+  user_attribute = "birthdate"
+  realm_id       = keycloak_openid_client.CLIENT.realm_id
+}
+
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-test/realms/moh_applications/clients/prime-webapp-enrollment/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prime-webapp-enrollment/main.tf
@@ -34,6 +34,13 @@ resource "keycloak_openid_audience_protocol_mapper" "Prime-Audience-Mapper" {
   name                     = "Prime Audience Mapper"
   realm_id                 = keycloak_openid_client.CLIENT.realm_id
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "birthdate" {
+  claim_name     = "birthdate"
+  client_id      = keycloak_openid_client.CLIENT.id
+  name           = "birthdate"
+  user_attribute = "birthdate"
+  realm_id       = keycloak_openid_client.CLIENT.realm_id
+}
 module "scope-mappings" {
   source    = "../../../../../modules/scope-mappings"
   realm_id  = keycloak_openid_client.CLIENT.realm_id


### PR DESCRIPTION
### Changes being made

Adding birthday attribute mappers to DMFT and PRIME applications on the test environment.

### Context

DMFT and PRIME are using the `birthdate` attribute, passed from BCSC. Currently, it's being passed to the token because of the `profile` scope. Those changes will allow removing the `birthdate` attribute from the scope so that other applications don't have access to it.
 
### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
