### PR TITLE
add hspp roles for test and prod

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
@@ -71,11 +71,17 @@ module "client-roles" {
     "HSPP_ReportProgram_Invictus" = {
       "name" = "HSPP_ReportProgram_Invictus"
     },
+    "HSPP_ReportProgram_OKR" = {
+      "name" = "HSPP_ReportProgram_OKR"
+    },
     "HSPP_ReportSection_All" = {
       "name" = "HSPP_ReportSection_All"
     },
     "HSPP_ReportSection_Invictus" = {
       "name" = "HSPP_ReportSection_Invictus"
+    },
+    "HSPP_ReportSection_OKR" = {
+      "name" = "HSPP_ReportSection_OKR"
     },
     "HSPP_Report_Invictus" = {
       "name" = "HSPP_Report_Invictus"

--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -72,11 +72,17 @@ module "client-roles" {
     "HSPP_ReportProgram_Invictus" = {
       "name" = "HSPP_ReportProgram_Invictus"
     },
+    "HSPP_ReportProgram_OKR" = {
+      "name" = "HSPP_ReportProgram_OKR"
+    },
     "HSPP_ReportSection_All" = {
       "name" = "HSPP_ReportSection_All"
     },
     "HSPP_ReportSection_Invictus" = {
       "name" = "HSPP_ReportSection_Invictus"
+    },
+    "HSPP_ReportSection_OKR" = {
+      "name" = "HSPP_ReportSection_OKR"
     },
     "HSPP_Report_Invictus" = {
       "name" = "HSPP_Report_Invictus"


### PR DESCRIPTION
### Changes being made

Adding `HSPP_ReportProgram_OKR `and `HSPP_ReportSection_OKR` roles to test and prod env for HSPP client, as per mailbox request.

 
### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]