### PR TITLE
Adding valid redirect URIs as

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
@@ -24,6 +24,8 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://bchealthprovider.ca/*",
     "https://www.bchealthprovider.ca/*",
     "https://healthbc.my.salesforce.com/*",
+    "https://healthbc--hlthbctrn.sandbox.my.salesforce.com/*",
+    "https://healthbc--hlthbctrn.sandbox.my.site.com/*",
   ]
   web_origins = [
   ]


### PR DESCRIPTION
### Changes being made

Adding valid redirect URIs as requested by Primary Care team through Renaldo

### Context

These are required as the training environment uses PROD users
 
### Quality Check

- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
