### PR TITLE
add redirect url to hspp test

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -22,6 +22,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "http://localhost:*",
     "https://localhost:*",
     "https://hsppstg.hlth.gov.bc.ca/*",
+    "https://devhspp.healthideas.gov.bc.ca/*",
   ]
   web_origins = [
   ]


### PR DESCRIPTION
### Changes being made

Adding hspp redirect URL on test environment.
 
### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
