### PR TITLE
Onboarding new FORMS client in Test

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -36,6 +36,9 @@ module "EMCOD" {
 module "FMDB" {
   source = "./clients/fmdb"
 }
+module "FORMS" {
+  source = "./clients/forms"
+}
 module "GIS" {
   source = "./clients/gis"
 }

--- a/keycloak-test/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/forms/main.tf
@@ -1,0 +1,60 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = "https://formstst.hlth.gov.bc.ca/"
+  client_authenticator_type           = "client-secret"
+  client_id                           = "FORMS"
+  consent_required                    = false
+  description                         = "Ministry of Health Public Forms Server"
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "FORMS"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+    "https://forms.ddev.site/*",
+    "https://formsdev.hlth.gov.bc.ca/*",
+    "https://formstst.hlth.gov.bc.ca/*",
+  ]
+  web_origins = [
+  ]
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "idir_company" {
+  add_to_id_token = true
+  add_to_userinfo = false
+  claim_name      = "idir_company"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "idir_company"
+  user_attribute  = "idir_company"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "email",
+    "profile",
+    "roles",
+    "web-origins"
+  ]
+}
+
+resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  optional_scopes = [
+    "address",
+    "microprofile-jwt",
+    "offline_access",
+    "phone"
+  ]
+}

--- a/keycloak-test/realms/moh_applications/clients/forms/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/forms/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/forms/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/forms/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Adding new FORMS Dev/Test client for Keycloak Test.

### Context

FORMS is a Drupal application looking to be onboarded in an expedited manner. See [AB#10435 - Add Dev/Test FORMS client configuration to Keycloak Test](https://dev.azure.com/cgi-vic-hlth/AM%20Team/_workitems/edit/10435) for more details.
 
### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [x] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
