### PR TITLE
add create and manage user roles to hspp group

### DIFF
--- a/keycloak-prod/realms/moh_applications/groups/hspp-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/groups/hspp-management/main.tf
@@ -8,7 +8,9 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
   group_id = keycloak_group.GROUP.id
 
   role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hspp"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,

--- a/keycloak-test/realms/moh_applications/groups/hspp-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/hspp-management/main.tf
@@ -8,7 +8,9 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
   group_id = keycloak_group.GROUP.id
 
   role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hspp"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,


### PR DESCRIPTION
### Changes being made

Assigning `create-user` and `manage-user-details` role to `HSPP Management` group on test and prod.

### Context

Mailbox request. HSPP business client would like to have pre-approved users to be added before they access keycloak. 
 
### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.