### PR TITLE
Add missing Redirect URIs for SiteMinder + PHSA logout

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/forms/main.tf
@@ -22,6 +22,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://forms.ddev.site/*",
     "https://formsdev.hlth.gov.bc.ca/*",
     "https://formstst.hlth.gov.bc.ca/*",
+    "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
   ]
   web_origins = [
   ]

--- a/keycloak-test/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/forms/main.tf
@@ -23,6 +23,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://formsdev.hlth.gov.bc.ca/*",
     "https://formstst.hlth.gov.bc.ca/*",
     "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
+    "https://sts.healthbc.org/adfs/ls/*",
   ]
   web_origins = [
   ]


### PR DESCRIPTION
### Changes being made

Add missing Redirect URIs for SiteMinder + PHSA logout to FORMS.

### Context

FORMS has SiteMinder + PHSA integrations and the logontest7.gov.bc.ca + sts.healthbc.org URIs must be added for chained logout to work.
 
### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
