### PR TITLE
dhiper test client

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -16,6 +16,9 @@ module "CONNECT" {
 module "DEMO-CLIENT" {
   source = "./clients/demo-client"
 }
+module "DHIPER" {
+  source = "./clients/dhiper"
+}
 module "DMFT-SERVICE" {
   source       = "./clients/dmft-service"
   PIDP-SERVICE = module.PIDP-SERVICE

--- a/keycloak-test/realms/moh_applications/clients/dhiper/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/dhiper/main.tf
@@ -59,11 +59,11 @@ module "client-roles" {
     "DHIPER_ALL" = {
       "name" = "DHIPER_ALL"
     },
-        "DHIPER_ReportSection_All" = {
+    "DHIPER_ReportSection_All" = {
       "name" = "DHIPER_ReportSection_All"
     },
-        "DHIPER_ReportProgram_All" = {
+    "DHIPER_ReportProgram_All" = {
       "name" = "DHIPER_ReportProgram_All"
-    }        
+    }
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/dhiper/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/dhiper/main.tf
@@ -1,0 +1,69 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "DHIPER"
+  consent_required                    = false
+  description                         = "Digital Health Initiatives Progress, Evaluation, and Results (DHIPER) Portal"
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "DHIPER"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+    "http://localhost:*",
+    "https://localhost:*",
+    "https://devdhiper.hlth.gov.bc.ca/*",
+    "https://uatdhiper.hlth.gov.bc.ca/*",
+    "https://sitdhiper.hlth.gov.bc.ca/*"
+  ]
+  web_origins = [
+  ]
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper" {
+  add_to_access_token         = true
+  add_to_id_token             = true
+  claim_name                  = "roles"
+  claim_value_type            = "String"
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "DHIPER"
+  multivalued                 = true
+  name                        = "client roles"
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "idir_displayName" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "idir_displayName"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "idir_displayName"
+  user_attribute  = "idir_displayName"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "DHIPER_ALL" = {
+      "name" = "DHIPER_ALL"
+    },
+        "DHIPER_ReportSection_All" = {
+      "name" = "DHIPER_ReportSection_All"
+    },
+        "DHIPER_ReportProgram_All" = {
+      "name" = "DHIPER_ReportProgram_All"
+    }        
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/dhiper/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/dhiper/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/dhiper/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/dhiper/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Creating DHIPER client on Keycloak Test environment. As for now, the client defines three roles and two mappers: role + IDIR.
The `dhiper.hlth.gov.bc.ca` URL was omitted from valid redirect URLs for now, as it seems it's Prod URL. Will follow up with the DHIPER team. `localhost` urls were added for development purpouses.

### Context

DHIPER is new application, and will be used to enable Ministry of Health users, specifically in the Digital Investment, Governance & Transformation (DIGT) branch access to the portal being developed by the Data Warehouse Services team.

Architecture-wise client is similar to HSPP.
 
### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [x] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.


[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
