### PR TITLE
create dhiper test admin group

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,21 +5,23 @@ Please include a short summary of the change.
 ### Context
 
 What is the context for those changes? For example: particular role needs to be shown in token. Reference Azure Board task, if applicable.
- 
+
 ### Quality Check
 
 - [ ] Client has Name and Description defined.
 - [ ] Full Scope Allowed is disabled.
 - [ ] Direct Access Grants Enabled is disabled.
-- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided. 
+- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
 - [ ] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
 - [ ] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
 - [ ] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
 - [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
 - [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
+- [ ] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]
 
 [^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
+[^2]:
+    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
+    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
 
-
-[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
-![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
+[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.

--- a/keycloak-test/realms/moh_applications/clients/user-management-service/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management-service/main.tf
@@ -49,6 +49,9 @@ module "client-roles" {
     "view-client-bcer-cp" = {
       "name" = "view-client-bcer-cp"
     },
+    "view-client-dhiper" = {
+      "name" = "view-client-dhiper"
+    },
     "view-client-dmft-webapp" = {
       "name" = "view-client-dmft-webapp"
     },

--- a/keycloak-test/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management/main.tf
@@ -57,6 +57,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/manage-own-groups"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-roles"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     "USER-MANAGEMENT-SERVICE/view-client-bcer-cp"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-dhiper"                    = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-dhiper"].id,
     "USER-MANAGEMENT-SERVICE/view-client-dmft-webappp"              = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-dmft-webapp"].id,
     "USER-MANAGEMENT-SERVICE/view-client-eacl"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl"].id,
     "USER-MANAGEMENT-SERVICE/view-client-eacl_stg"                  = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl_stg"].id,

--- a/keycloak-test/realms/moh_applications/groups.tf
+++ b/keycloak-test/realms/moh_applications/groups.tf
@@ -32,6 +32,11 @@ module "CGI-REGISTRIES" {
   HCIMWEB_HUAT  = module.HCIMWEB_HUAT
 }
 
+module "DHIPER-MANAGEMENT" {
+  source                  = "./groups/dhiper-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
 module "EMCOD-ACCESS-TEAM" {
   source                  = "./groups/emcod-access-team"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE

--- a/keycloak-test/realms/moh_applications/groups/dhiper-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/dhiper-management/main.tf
@@ -1,0 +1,21 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "DHIPER Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-dhiper"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/dhiper-management/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/dhiper-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/dhiper-management/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/dhiper-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/dhiper-management/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/dhiper-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/realm-roles/manage-users/main.tf
+++ b/keycloak-test/realms/moh_applications/realm-roles/manage-users/main.tf
@@ -6,6 +6,7 @@ resource "keycloak_role" "REALM_ROLE" {
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-dhiper"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-dmft-webapp"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl_stg"].id,


### PR DESCRIPTION
### Changes being made

Creating DHIPER management group on test env. The permissions are similar to HSPP Admin group.
Added `view-client-dhiper` role to UMC/UMS.

### Context

The group will allow DHIPER team to manage authorization through UMC.
 
### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
