### PR TITLE
create ehpr test client

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -33,6 +33,9 @@ module "EACL" {
 module "EACL_STG" {
   source = "./clients/eacl_stg"
 }
+module "EHPR" {
+  source = "./clients/ehpr"
+}
 module "EMCOD" {
   source = "./clients/emcod"
 }

--- a/keycloak-test/realms/moh_applications/clients/ehpr/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/ehpr/main.tf
@@ -1,0 +1,39 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "EHPR"
+  consent_required                    = false
+  description                         = "Emergency Health Provider Registry."
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "EHPR"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+    "http://localhost:*",
+    "https://localhost:*",
+    "https://dev.ehpr.freshworks.club/*",
+    "https://test.ehpr.freshworks.club/*"
+  ]
+  web_origins = [
+  ]
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "org_details" {
+  add_to_id_token = false
+  add_to_userinfo = false
+  claim_name      = "org_details"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "org_details"
+  user_attribute  = "org_details"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-test/realms/moh_applications/clients/ehpr/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/ehpr/main.tf
@@ -27,13 +27,3 @@ resource "keycloak_openid_client" "CLIENT" {
   web_origins = [
   ]
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "org_details" {
-  add_to_id_token = false
-  add_to_userinfo = false
-  claim_name      = "org_details"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "org_details"
-  user_attribute  = "org_details"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/ehpr/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/ehpr/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "EHPR"
   consent_required                    = false
-  description                         = "Emergency Health Provider Registry."
+  description                         = "Emergency Health Provider Registry. Health workers can sign up at https://ehpr.gov.bc.ca/. In times of flood, earthquake, or wildfire, registrants may be called up to help."
   direct_access_grants_enabled        = false
   enabled                             = true
   frontchannel_logout_enabled         = false
@@ -19,8 +19,6 @@ resource "keycloak_openid_client" "CLIENT" {
   standard_flow_enabled               = true
   use_refresh_tokens                  = true
   valid_redirect_uris = [
-    "http://localhost:*",
-    "https://localhost:*",
     "https://dev.ehpr.freshworks.club/*",
     "https://test.ehpr.freshworks.club/*"
   ]

--- a/keycloak-test/realms/moh_applications/clients/ehpr/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/ehpr/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/ehpr/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/ehpr/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Created EHPR client with org_details mapper.

### Context

EHPR is the Emergency Health Provider Registry. Health workers can sign up at https://ehpr.gov.bc.ca/. In times of flood, earthquake, or wildfire, registrants may be called up to help.

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [x] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
