### PR TITLE
10417-Client Onboarding - HealthLink BC: adding dev and test config

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients.tf
+++ b/keycloak-dev/realms/moh_applications/clients.tf
@@ -39,6 +39,9 @@ module "HCIM-SERVICE" {
 module "HEM" {
   source = "./clients/hem"
 }
+module "HLBC" {
+  source = "./clients/hlbc"
+}
 module "IEN" {
   source = "./clients/ien"
 }

--- a/keycloak-dev/realms/moh_applications/clients/hlbc/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/hlbc/main.tf
@@ -1,0 +1,64 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = "https://www-dev.healthlinkbc.ca/"
+  client_authenticator_type           = "client-secret"
+  client_id                           = "HLBC"
+  consent_required                    = false
+  description                         = "HealthlinkBC is an informational website for the public. They can search for health-related questions on the site. The site is managed by HLBC users with different roles."
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "HLBC"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  valid_redirect_uris = [
+    "https://fusion.ddev.site/*",
+    "https://www-dev.healthlinkbc.ca/*",
+    "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
+  ]
+  web_origins = [
+  ]
+}
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "ANONYMOUS_USER" = {
+      "name" = "ANONYMOUS_USER"
+    },
+    "AUTHENTICATED_USER" = {
+      "name" = "AUTHENTICATED_USER"
+    },
+    "SITE_ADMINISTRATOR" = {
+      "name" = "SITE_ADMINISTRATOR"
+    },
+    "CONTENT_ADMINISTRATOR" = {
+      "name" = "CONTENT_ADMINISTRATOR"
+    },
+    "CONTENT_EDITOR" = {
+      "name" = "CONTENT_EDITOR"
+    },
+    "CONTENT_CONTRIBUTOR" = {
+      "name" = "CONTENT_CONTRIBUTOR"
+    },
+    "DEVELOPER" = {
+      "name" = "DEVELOPER"
+    },
+    "DIGITAL_ANALYST" = {
+      "name" = "DIGITAL_ANALYST"
+    },
+    "CLINICAL" = {
+      "name" = "CLINICAL"
+    },
+    "DATA_STEWARD" = {
+      "name" = "DATA_STEWARD"
+    },
+  }
+}

--- a/keycloak-dev/realms/moh_applications/clients/hlbc/outputs.tf
+++ b/keycloak-dev/realms/moh_applications/clients/hlbc/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-dev/realms/moh_applications/clients/hlbc/variables.tf
+++ b/keycloak-dev/realms/moh_applications/clients/hlbc/variables.tf
@@ -1,0 +1,1 @@
+variable "HLBC" {}

--- a/keycloak-dev/realms/moh_applications/clients/hlbc/variables.tf
+++ b/keycloak-dev/realms/moh_applications/clients/hlbc/variables.tf
@@ -1,1 +1,0 @@
-variable "HLBC" {}

--- a/keycloak-dev/realms/moh_applications/clients/hlbc/versions.tf
+++ b/keycloak-dev/realms/moh_applications/clients/hlbc/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -89,6 +89,9 @@ module "HEM" {
 module "HHSLibrary" {
   source = "./clients/hhs-library"
 }
+module "HLBC" {
+  source = "./clients/hlbc"
+}
 module "hnsesb_api_gateway_client_manager" {
   source           = "./clients/hnsesb_api_gateway_client_manager"
   realm-management = module.realm-management

--- a/keycloak-test/realms/moh_applications/clients/hlbc/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hlbc/main.tf
@@ -1,0 +1,64 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = "https://www-test.healthlinkbc.ca/"
+  client_authenticator_type           = "client-secret"
+  client_id                           = "HLBC"
+  consent_required                    = false
+  description                         = "HealthlinkBC is an informational website for the public. They can search for health-related questions on the site. The site is managed by HLBC users with different roles."
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "HLBC"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  valid_redirect_uris = [
+    "https://fusion.ddev.site/*",
+    "https://www-test.healthlinkbc.ca/*",
+    "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
+  ]
+  web_origins = [
+  ]
+}
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "ANONYMOUS_USER" = {
+      "name" = "ANONYMOUS_USER"
+    },
+    "AUTHENTICATED_USER" = {
+      "name" = "AUTHENTICATED_USER"
+    },
+    "SITE_ADMINISTRATOR" = {
+      "name" = "SITE_ADMINISTRATOR"
+    },
+    "CONTENT_ADMINISTRATOR" = {
+      "name" = "CONTENT_ADMINISTRATOR"
+    },
+    "CONTENT_EDITOR" = {
+      "name" = "CONTENT_EDITOR"
+    },
+    "CONTENT_CONTRIBUTOR" = {
+      "name" = "CONTENT_CONTRIBUTOR"
+    },
+    "DEVELOPER" = {
+      "name" = "DEVELOPER"
+    },
+    "DIGITAL_ANALYST" = {
+      "name" = "DIGITAL_ANALYST"
+    },
+    "CLINICAL" = {
+      "name" = "CLINICAL"
+    },
+    "DATA_STEWARD" = {
+      "name" = "DATA_STEWARD"
+    },
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/hlbc/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/hlbc/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/hlbc/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/hlbc/variables.tf
@@ -1,0 +1,1 @@
+variable "HLBC" {}

--- a/keycloak-test/realms/moh_applications/clients/hlbc/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/hlbc/variables.tf
@@ -1,1 +1,0 @@
-variable "HLBC" {}

--- a/keycloak-test/realms/moh_applications/clients/hlbc/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/hlbc/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Adding dev and test config for onboarding HealthLink BC as a client

### Context

HealthLink BC wishes to use OIDC for authentication

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 