### PR TITLE
add redirect uris for ehpr

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/ehpr/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/ehpr/main.tf
@@ -20,7 +20,9 @@ resource "keycloak_openid_client" "CLIENT" {
   use_refresh_tokens                  = true
   valid_redirect_uris = [
     "https://dev.ehpr.freshworks.club/*",
-    "https://test.ehpr.freshworks.club/*"
+    "https://test.ehpr.freshworks.club/*",
+    "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
+    "https://sts.healthbc.org/adfs/ls/*",
   ]
   web_origins = [
   ]


### PR DESCRIPTION
### Changes being made

Adding redirect URLs for EHPR client on the Test environment.

### Context

EHPR requires IDIR and Health Authorities login.

### Quality Check

- [ ] Valid Redirect URIs are properly defined, or an explanation for `*` (allow all) is provided.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
