### PR TITLE
Add identity_provider to id token on METASPACE Dev client

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/metaspace/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/metaspace/main.tf
@@ -29,7 +29,7 @@ resource "keycloak_openid_client" "CLIENT" {
 }
 
 resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
-  add_to_id_token  = false
+  add_to_id_token  = true
   claim_name       = "identity_provider"
   claim_value_type = "String"
   client_id        = keycloak_openid_client.CLIENT.id


### PR DESCRIPTION
### Changes being made

Add `identity_provider` to id token on METASPACE Dev client

### Context

Drupal applications only really care about the id token since roles are managed through the application, so having `identity_provider` only available through the access token (where we normally put it) isn't ideal for them.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)