### PR TITLE
create plr-shoppers prod client

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients.tf
+++ b/keycloak-prod/realms/moh_applications/clients.tf
@@ -124,6 +124,10 @@ module "PIDP-WEBAPP" {
 module "PLR" {
   source = "./clients/plr"
 }
+module "PLR-SHOPPERS" {
+  source = "./clients/plr-shoppers"
+  PLR    = module.PLR
+}
 module "PRIMARY-CARE" {
   source         = "./clients/primary-care"
   LICENCE-STATUS = module.LICENCE-STATUS

--- a/keycloak-prod/realms/moh_applications/clients/plr-shoppers/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/plr-shoppers/main.tf
@@ -1,0 +1,86 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = "18000"
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "PLR-SHOPPERS"
+  consent_required                    = false
+  description                         = "This client allows Shoppers Drugmart to access PLR."
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "PLR-SHOPPERS"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = true
+  standard_flow_enabled               = false
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+resource "keycloak_openid_hardcoded_claim_protocol_mapper" "orgId" {
+  add_to_access_token = true
+  add_to_id_token     = true
+  add_to_userinfo     = true
+  claim_name          = "orgId"
+  claim_value         = "00024727"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "orgId"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+resource "keycloak_openid_user_session_note_protocol_mapper" "Client-Host" {
+  add_to_id_token  = true
+  claim_name       = "clientHost"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "Client Host"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "clientHost"
+}
+resource "keycloak_openid_user_session_note_protocol_mapper" "Client-ID" {
+  add_to_id_token  = true
+  claim_name       = "clientId"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "Client ID"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "clientId"
+}
+resource "keycloak_openid_user_session_note_protocol_mapper" "Client-IP-Address" {
+  add_to_id_token  = true
+  claim_name       = "clientAddress"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "Client IP Address"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "clientAddress"
+}
+module "service-account-roles" {
+  source                  = "../../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {
+    "PLR/CONSUMER" = {
+      "client_id" = var.PLR.CLIENT.id,
+      "role_id"   = "CONSUMER"
+    }
+  }
+}
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "PLR/CONSUMER" = var.PLR.ROLES["CONSUMER"].id
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/plr-shoppers/outputs.tf
+++ b/keycloak-prod/realms/moh_applications/clients/plr-shoppers/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-prod/realms/moh_applications/clients/plr-shoppers/variables.tf
+++ b/keycloak-prod/realms/moh_applications/clients/plr-shoppers/variables.tf
@@ -1,0 +1,1 @@
+variable "PLR" {}

--- a/keycloak-prod/realms/moh_applications/clients/plr-shoppers/versions.tf
+++ b/keycloak-prod/realms/moh_applications/clients/plr-shoppers/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Creating PLR-SHOPPERs client on prod environment. The PLR team specified the org as 00024727 in their request. The rest of the config is as in PLR-SHOPPERS on test environment. 


### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [ ] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
