### PR TITLE
Adding bceid_business_legalName mapper for METASPACE Dev

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/metaspace/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/metaspace/main.tf
@@ -48,6 +48,16 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "idir_company" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_attribute_protocol_mapper" "bceid_business_legalName" {
+  add_to_id_token = true
+  add_to_userinfo = false
+  claim_name      = "bceid_business_legalName"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "bceid_business_legalName"
+  user_attribute  = "bceid_business_legalName"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id


### PR DESCRIPTION
### Changes being made

Adding `bceid_business_legalName` mapper for METASPACE Dev.

### Context

Hemant has requested the `bceid_business_legalName` attribute be mapped similar to the `idir_company` on METASPACE Dev.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)