### PR TITLE
grant-umc-dashboard-access-to-hspp

### DIFF
--- a/keycloak-prod/realms/moh_applications/groups/hspp-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/groups/hspp-management/main.tf
@@ -16,6 +16,7 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
     var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-metrics"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
   ]
 }

--- a/keycloak-test/realms/moh_applications/groups/hspp-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/hspp-management/main.tf
@@ -16,6 +16,7 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
     var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-metrics"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
   ]
 }


### PR DESCRIPTION
### Changes being made

Granting HSPP admin group access to UMC dashboard in prod and test, so they can see login statistics.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 
