### PR TITLE
Add localhost to HEM Test

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/hem/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hem/main.tf
@@ -15,6 +15,8 @@ module "payara-client" {
   }
   service_accounts_enabled = false
   valid_redirect_uris = [
+    "http://localhost:8080/*",
+    "https://localhost:8081/*",
     "https://hemuat.hlth.gov.bc.ca/*",
     "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
   ]


### PR DESCRIPTION
### Changes being made

Adding localhost Redirect URIs to HEM Test.

### Context

I can't connect from my localhost.

### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)