### PR TITLE
Adding IDP mapper for FORMS (like METASPACE)

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/forms/main.tf
@@ -28,6 +28,16 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
+resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
+  add_to_id_token  = true
+  claim_name       = "identity_provider"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "IDP"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "identity_provider"
+}
+
 resource "keycloak_openid_user_attribute_protocol_mapper" "idir_company" {
   add_to_id_token = true
   add_to_userinfo = false

--- a/keycloak-prod/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/forms/main.tf
@@ -30,6 +30,16 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
+resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
+  add_to_id_token  = true
+  claim_name       = "identity_provider"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "IDP"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "identity_provider"
+}
+
 resource "keycloak_openid_user_attribute_protocol_mapper" "idir_company" {
   add_to_id_token = true
   add_to_userinfo = false

--- a/keycloak-test/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/forms/main.tf
@@ -29,6 +29,16 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
+resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
+  add_to_id_token  = true
+  claim_name       = "identity_provider"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "IDP"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "identity_provider"
+}
+
 resource "keycloak_openid_user_attribute_protocol_mapper" "idir_company" {
   add_to_id_token = true
   add_to_userinfo = false


### PR DESCRIPTION
### Changes being made

Adding IDP mapper for FORMS (like METASPACE).

### Context

Mael has requested we add the IDP mapper to all FORMS clients, mirroring what was done for Hemant on the METASPACE clients.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]: Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
