### PR TITLE
remvoed defaulted mappers

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/ppm-api-cgi-BC30550160/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/ppm-api-cgi-BC30550160/main.tf
@@ -24,36 +24,6 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
-resource "keycloak_openid_user_session_note_protocol_mapper" "Client-Host" {
-  add_to_id_token  = true
-  claim_name       = "clientHost"
-  claim_value_type = "String"
-  client_id        = keycloak_openid_client.CLIENT.id
-  name             = "Client Host"
-  realm_id         = keycloak_openid_client.CLIENT.realm_id
-  session_note     = "clientHost"
-}
-
-resource "keycloak_openid_user_session_note_protocol_mapper" "Client-ID" {
-  add_to_id_token  = true
-  claim_name       = "clientId"
-  claim_value_type = "String"
-  client_id        = keycloak_openid_client.CLIENT.id
-  name             = "Client ID"
-  realm_id         = keycloak_openid_client.CLIENT.realm_id
-  session_note     = "clientId"
-}
-
-resource "keycloak_openid_user_session_note_protocol_mapper" "Client-IP-Address" {
-  add_to_id_token  = true
-  claim_name       = "clientAddress"
-  claim_value_type = "String"
-  client_id        = keycloak_openid_client.CLIENT.id
-  name             = "Client IP Address"
-  realm_id         = keycloak_openid_client.CLIENT.realm_id
-  session_note     = "clientAddress"
-}
-
 resource "keycloak_openid_user_session_note_protocol_mapper" "Pharmanet-Audience" {
   add_to_id_token  = false
   claim_name       = "pharmanet"


### PR DESCRIPTION
### Changes being made

Remvoed defaulted mappers.

### Context

"Client Host", "Client ID" and "Client IP Address" mappers get created by default on client creation so explicitly defining them is unnecessary and caused an error in Terraform

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
