### PR TITLE
create lra non-prod clients

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -129,6 +129,21 @@ module "LDAP-API" {
 module "LICENCE-STATUS" {
   source = "./clients/licence-status"
 }
+module "LRA-DEV" {
+  source         = "./clients/lra-dev"
+  LICENCE-STATUS = module.LICENCE-STATUS
+
+}
+module "LRA-SANDBOX" {
+  source         = "./clients/lra-sandbox"
+  LICENCE-STATUS = module.LICENCE-STATUS
+
+}
+module "LRA-TEST" {
+  source         = "./clients/lra-test"
+  LICENCE-STATUS = module.LICENCE-STATUS
+
+}
 module "MAID" {
   source = "./clients/maid"
 }

--- a/keycloak-test/realms/moh_applications/clients/lra-dev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-dev/main.tf
@@ -1,0 +1,40 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "LRA-DEV"
+  consent_required                    = false
+  description                         = "Longitudinal Record Access. Dev Environment. LRA is a FHIR Server to access Longitudinal Health Records."
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "LRA-DEV"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+    "http://localhost:*",
+    "https://localhost:*",
+  ]
+  web_origins = [
+  ]
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper-LICENCE-STATUS" {
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "LICENCE-STATUS"
+  name                        = "Client Role Mapper for LICENCE-STATUS"
+  claim_name                  = "roles"
+  multivalued                 = true
+  claim_value_type            = "String"
+  add_to_id_token             = true
+  add_to_access_token         = true
+  add_to_userinfo             = true
+}

--- a/keycloak-test/realms/moh_applications/clients/lra-dev/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-dev/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/lra-dev/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-dev/variables.tf
@@ -1,0 +1,1 @@
+variable "LICENCE-STATUS" {}

--- a/keycloak-test/realms/moh_applications/clients/lra-dev/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-dev/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/lra-sandbox/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-sandbox/main.tf
@@ -1,0 +1,40 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "LRA-SANDBOX"
+  consent_required                    = false
+  description                         = "Longitudinal Record Access. Sandbox Environment. LRA is a FHIR Server to access Longitudinal Health Records."
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "LRA-SANDBOX"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+    "http://localhost:*",
+    "https://localhost:*",
+  ]
+  web_origins = [
+  ]
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper-LICENCE-STATUS" {
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "LICENCE-STATUS"
+  name                        = "Client Role Mapper for LICENCE-STATUS"
+  claim_name                  = "roles"
+  multivalued                 = true
+  claim_value_type            = "String"
+  add_to_id_token             = true
+  add_to_access_token         = true
+  add_to_userinfo             = true
+}

--- a/keycloak-test/realms/moh_applications/clients/lra-sandbox/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-sandbox/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/lra-sandbox/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-sandbox/variables.tf
@@ -1,0 +1,1 @@
+variable "LICENCE-STATUS" {}

--- a/keycloak-test/realms/moh_applications/clients/lra-sandbox/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-sandbox/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/lra-test/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-test/main.tf
@@ -1,0 +1,40 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "LRA-TEST"
+  consent_required                    = false
+  description                         = "Longitudinal Record Access. Test Environment. LRA is a FHIR Server to access Longitudinal Health Records."
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "LRA-TEST"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+    "http://localhost:*",
+    "https://localhost:*",
+  ]
+  web_origins = [
+  ]
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper-LICENCE-STATUS" {
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "LICENCE-STATUS"
+  name                        = "Client Role Mapper for LICENCE-STATUS"
+  claim_name                  = "roles"
+  multivalued                 = true
+  claim_value_type            = "String"
+  add_to_id_token             = true
+  add_to_access_token         = true
+  add_to_userinfo             = true
+}

--- a/keycloak-test/realms/moh_applications/clients/lra-test/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-test/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/lra-test/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-test/variables.tf
@@ -1,0 +1,1 @@
+variable "LICENCE-STATUS" {}

--- a/keycloak-test/realms/moh_applications/clients/lra-test/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-test/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Creating 3 clients for LRA (Dev, Test, Sandbox) on the Keycloak Test environment. For now, each client has `localhost` configured as valid redirect URLs. This configuration will be updated once we know more details. 
Each client has a client role mapper defined, that allows to pass roles from LICENSE-STATUS inside a token.

### Context

LRA is an application that allows users to access Longitudinal Health Records. 
CMDB is not updated yet.

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [x] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
