### PR TITLE
add HI_ADMINISTRATOR role to PRP

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/prp-service/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prp-service/main.tf
@@ -18,6 +18,12 @@ module "client-roles" {
   client_id = keycloak_openid_client.CLIENT.id
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   roles = {
+    "HI_ADMINISTRATOR" = {
+      "name" = "HI_ADMINISTRATOR"
+    },
+    "MSPQI" = {
+      "name" = "MSPQI"
+    },
     "PHARMACIST" = {
       "name" = "PHARMACIST"
     },
@@ -27,8 +33,5 @@ module "client-roles" {
     "PMP" = {
       "name" = "PMP"
     },
-    "MSPQI" = {
-      "name" = "MSPQI"
-    }
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
@@ -48,9 +48,10 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "PRP-SERVICE/PHYSICIAN"  = var.PRP-SERVICE.ROLES["PHYSICIAN"].id,
-    "PRP-SERVICE/PHARMACIST" = var.PRP-SERVICE.ROLES["PHARMACIST"].id,
-    "PRP-SERVICE/PMP"        = var.PRP-SERVICE.ROLES["PMP"].id,
-    "PRP-SERVICE/MSPQI"      = var.PRP-SERVICE.ROLES["MSPQI"].id,
+    "PRP-SERVICE/HI_ADMINISTRATOR" = var.PRP-SERVICE.ROLES["HI_ADMINISTRATOR"].id,
+    "PRP-SERVICE/MSPQI"            = var.PRP-SERVICE.ROLES["MSPQI"].id,
+    "PRP-SERVICE/PHYSICIAN"        = var.PRP-SERVICE.ROLES["PHYSICIAN"].id,
+    "PRP-SERVICE/PHARMACIST"       = var.PRP-SERVICE.ROLES["PHARMACIST"].id,
+    "PRP-SERVICE/PMP"              = var.PRP-SERVICE.ROLES["PMP"].id,
   }
 }


### PR DESCRIPTION
### Changes being made

Adding administrator role to PRP-SERVICE. Updating PRP-WEB scopes, so the new role shows up in the token. Sorted the roles alphabetically. 

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.