### PR TITLE
remove DOB mapper from pidp-service

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/pidp-service/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/pidp-service/main.tf
@@ -69,13 +69,6 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "Client-IP-Address"
   realm_id         = keycloak_openid_client.CLIENT.realm_id
   session_note     = "clientAddress"
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "birthdate" {
-  claim_name     = "birthdate"
-  client_id      = keycloak_openid_client.CLIENT.id
-  name           = "birthdate"
-  user_attribute = "birthdate"
-  realm_id       = keycloak_openid_client.CLIENT.realm_id
-}
 module "scope-mappings" {
   source    = "../../../../../modules/scope-mappings"
   realm_id  = keycloak_openid_client.CLIENT.realm_id


### PR DESCRIPTION
### Changes being made

Removing DOB mapper from PIDP-SERVICE client on test environment. 

### Context

PIDP-SERVICE is a client that represents service account, utilized for API calls. It it safe to assume, that it does not need a DOB attribute to be passed within the token.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.