### PR TITLE
add role mapper for prp-web on test

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
@@ -43,6 +43,18 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "common_provider_numbe
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper" {
+  add_to_access_token         = true
+  add_to_id_token             = true
+  claim_name                  = "roles"
+  claim_value_type            = "String"
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "PRP-SERVICE"
+  multivalued                 = true
+  name                        = "client roles"
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}
+
 module "scope-mappings" {
   source    = "../../../../../modules/scope-mappings"
   realm_id  = keycloak_openid_client.CLIENT.realm_id


### PR DESCRIPTION
### Changes being made

Adding role mapper to PRP-WEB on Test environment.

### Context

PRP-WEB wants to have it's roles passed in "roles" claim, not in "resource-access" claim, to follow the architectural patterns of HSPP and DHIPER.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.
