### PR TITLE
enable CORS and add redirect URL for EHPR client

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/ehpr/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/ehpr/main.tf
@@ -23,7 +23,9 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://test.ehpr.freshworks.club/*",
     "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
     "https://sts.healthbc.org/adfs/ls/*",
+    "http://localhost:3000/*",
   ]
   web_origins = [
+    "+"
   ]
 }


### PR DESCRIPTION
### Changes being made

Allowing CORS from domains included in the valid redirect URLs section. Adding localhost as valid redirect URL.

### Context

EHPR team reported CORS issues.

### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
