### PR TITLE
HCAP: added role in test

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/hcap-fe/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcap-fe/main.tf
@@ -48,6 +48,9 @@ module "client-roles" {
     "maximus" = {
       "name" = "maximus"
     },
+    "mhsu-employer" = {
+      "name" = "mhsu-employer"
+    },
     "ministry_of_health" = {
       "name" = "ministry_of_health"
     },


### PR DESCRIPTION
### Changes being made

Adding new role "mhsu-employer" to HCAP client

### Context

HCAP requires the new role "mhsu-employer"

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
