### PR TITLE
pass licence status to prp-web on test

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -346,8 +346,9 @@ module "PRP-SERVICE" {
   source = "./clients/prp-service"
 }
 module "PRP-WEB" {
-  source      = "./clients/prp-web"
-  PRP-SERVICE = module.PRP-SERVICE
+  source         = "./clients/prp-web"
+  PRP-SERVICE    = module.PRP-SERVICE
+  LICENCE-STATUS = module.LICENCE-STATUS
 }
 module "SAT-EFORMS" {
   source = "./clients/sat-eforms"

--- a/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
@@ -15,6 +15,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://sitprp.hlth.gov.bc.ca/*",
     "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
     "https://uatprp.hlth.gov.bc.ca/*",
+    "https://localhost:*",
   ]
   web_origins = [
     "*",
@@ -22,17 +23,18 @@ resource "keycloak_openid_client" "CLIENT" {
 }
 
 resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
-  add_to_id_token  = false
-  claim_name       = "identity_provider"
-  claim_value_type = "String"
-  client_id        = keycloak_openid_client.CLIENT.id
-  name             = "IDP"
-  realm_id         = keycloak_openid_client.CLIENT.realm_id
-  session_note     = "identity_provider"
+  add_to_access_token = true
+  add_to_id_token     = true
+  claim_name          = "identity_provider"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "IDP"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+  session_note        = "identity_provider"
 }
 
 resource "keycloak_openid_user_attribute_protocol_mapper" "common_provider_number" {
-  add_to_id_token     = false
+  add_to_id_token     = true
   add_to_userinfo     = true
   add_to_access_token = true
   claim_name          = "common_provider_number"
@@ -55,6 +57,18 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_client_role_protocol_mapper" "licence_status_role_mapper" {
+  add_to_access_token         = true
+  add_to_id_token             = true
+  claim_name                  = "licence_status"
+  claim_value_type            = "String"
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "LICENCE-STATUS"
+  multivalued                 = true
+  name                        = "licence status"
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}
+
 module "scope-mappings" {
   source    = "../../../../../modules/scope-mappings"
   realm_id  = keycloak_openid_client.CLIENT.realm_id
@@ -65,5 +79,9 @@ module "scope-mappings" {
     "PRP-SERVICE/Physician"        = var.PRP-SERVICE.ROLES["Physician"].id,
     "PRP-SERVICE/Pharmacist"       = var.PRP-SERVICE.ROLES["Pharmacist"].id,
     "PRP-SERVICE/Pmp"              = var.PRP-SERVICE.ROLES["Pmp"].id,
+    "LICENCE-STATUS/MOA"           = var.LICENCE-STATUS.ROLES["MOA"].id
+    "LICENCE-STATUS/PRACTITIONER"  = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
+    "LICENCE-STATUS/MD"            = var.LICENCE-STATUS.ROLES["MD"].id
+    "LICENCE-STATUS/RNP"           = var.LICENCE-STATUS.ROLES["RNP"].id
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/prp-web/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/prp-web/variables.tf
@@ -1,1 +1,2 @@
 variable "PRP-SERVICE" {}
+variable "LICENCE-STATUS" {}


### PR DESCRIPTION
### Changes being made

PRP-WEB client changes: adding redirect URL, configuring a mapper to include LICENCE-STATUS in ID Token. Including CPN and IDP in the ID Token.

### Context

PRP-WEB needs those attributes to comply with new architecture changes.

### Quality Check


- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.