### PR TITLE
create sat-eforms role test and prod

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/sat-eforms/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/sat-eforms/main.tf
@@ -32,11 +32,14 @@ module "client-roles" {
   client_id = keycloak_openid_client.CLIENT.id
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   roles = {
-    "phsa_eforms_sat" = {
-      "name" = "phsa_eforms_sat"
+    "phsa_eforms_immsbc" = {
+      "name" = "phsa_eforms_immsbc"
     },
     "phsa_eforms_rxrefill" = {
       "name" = "phsa_eforms_rxrefill"
+    },
+    "phsa_eforms_sat" = {
+      "name" = "phsa_eforms_sat"
     },
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/sat-eforms/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sat-eforms/main.tf
@@ -31,11 +31,14 @@ module "client-roles" {
   client_id = keycloak_openid_client.CLIENT.id
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   roles = {
-    "phsa_eforms_sat" = {
-      "name" = "phsa_eforms_sat"
+    "phsa_eforms_immsbc" = {
+      "name" = "phsa_eforms_immsbc"
     },
     "phsa_eforms_rxrefill" = {
       "name" = "phsa_eforms_rxrefill"
+    },
+    "phsa_eforms_sat" = {
+      "name" = "phsa_eforms_sat"
     },
   }
 }


### PR DESCRIPTION
### Changes being made

Adding a role to SAT-EFORMS on test and prod environment. 

### Context

New role in SAT-EFORMS. PIDP service account needs the ability to assign this role. This was previously ensured, by adding UMS roles: `view-client-sat-eforms` and `manage-user-roles` to the service account.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.
