### PR TITLE
Adding new GIS Test redirect_uri

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/gis/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/gis/main.tf
@@ -22,5 +22,6 @@ module "payara-client" {
     "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
     "https://sts.healthbc.org/adfs/ls/*",
     "https://gis.ynr9ed-dev.nimbus.cloud.gov.bc.ca/gis/*",
+    "https://gis.ynr9ed-test.nimbus.cloud.gov.bc.ca/gis/*",
   ]
 }


### PR DESCRIPTION
### Changes being made

Adding new GIS Test redirect_uri.

### Context

A new AWS redirect_uri for GIS Test is required by the Cloud Migration project.

### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)