### PR TITLE
Change prp web confidentiality

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
@@ -1,14 +1,23 @@
 resource "keycloak_openid_client" "CLIENT" {
-  access_token_lifespan      = ""
-  access_type                = "CONFIDENTIAL"
-  client_authenticator_type  = "client-secret"
-  client_id                  = "PRP-WEB"
-  description                = "Provider Reporting Portal Frontend"
-  full_scope_allowed         = false
-  name                       = "PRP Web"
-  pkce_code_challenge_method = "S256"
-  realm_id                   = "moh_applications"
-  standard_flow_enabled      = true
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "PRP-WEB"
+  consent_required                    = false
+  description                         = "Provider Reporting Portal Frontend"
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "PRP Web"
+  pkce_code_challenge_method          = "S256"
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = true
   valid_redirect_uris = [
     "http://localhost:*",
     "https://wonderful-cliff-0d1cec610.2.azurestaticapps.net/*",

--- a/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
@@ -1,6 +1,6 @@
 resource "keycloak_openid_client" "CLIENT" {
   access_token_lifespan      = ""
-  access_type                = "PUBLIC"
+  access_type                = "CONFIDENTIAL"
   client_authenticator_type  = "client-secret"
   client_id                  = "PRP-WEB"
   description                = "Provider Reporting Portal Frontend"


### PR DESCRIPTION
### Changes being made

Setting the type of PRP-WEB client as confidential. The other settings, such as `service-accounts enabled` were derived from DHIPER and HSPP clients. Those applications follow the same architecture pattern.

### Context

PRP-WEB & CLIIP architecture changes.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.