### PR TITLE
add birthdate mappers to prod clients

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/dmft-webapp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/dmft-webapp/main.tf
@@ -41,6 +41,14 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_attribute_protocol_mapper" "birthdate" {
+  claim_name     = "birthdate"
+  client_id      = keycloak_openid_client.CLIENT.id
+  name           = "birthdate"
+  user_attribute = "birthdate"
+  realm_id       = keycloak_openid_client.CLIENT.realm_id
+}
+
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-prod/realms/moh_applications/clients/pidp-webapp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/pidp-webapp/main.tf
@@ -33,6 +33,15 @@ resource "keycloak_openid_audience_protocol_mapper" "PIDP-SERVICE-aud-mapper" {
   name                     = "PIDP-SERVICE aud mapper"
   realm_id                 = keycloak_openid_client.CLIENT.realm_id
 }
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "birthdate" {
+  claim_name     = "birthdate"
+  client_id      = keycloak_openid_client.CLIENT.id
+  name           = "birthdate"
+  user_attribute = "birthdate"
+  realm_id       = keycloak_openid_client.CLIENT.realm_id
+}
+
 resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider" {
   add_to_id_token  = false
   claim_name       = "identity_provider"

--- a/keycloak-prod/realms/moh_applications/clients/prime-application/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/prime-application/main.tf
@@ -73,6 +73,14 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "identity_assurance_le
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_attribute_protocol_mapper" "birthdate" {
+  claim_name     = "birthdate"
+  client_id      = keycloak_openid_client.CLIENT.id
+  name           = "birthdate"
+  user_attribute = "birthdate"
+  realm_id       = keycloak_openid_client.CLIENT.realm_id
+}
+
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-prod/realms/moh_applications/clients/prime-webapp-enrollment/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/prime-webapp-enrollment/main.tf
@@ -32,6 +32,15 @@ resource "keycloak_openid_audience_protocol_mapper" "Prime-Audience-Mapper" {
   name                     = "Prime Audience Mapper"
   realm_id                 = keycloak_openid_client.CLIENT.realm_id
 }
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "birthdate" {
+  claim_name     = "birthdate"
+  client_id      = keycloak_openid_client.CLIENT.id
+  name           = "birthdate"
+  user_attribute = "birthdate"
+  realm_id       = keycloak_openid_client.CLIENT.realm_id
+}
+
 module "scope-mappings" {
   source    = "../../../../../modules/scope-mappings"
   realm_id  = keycloak_openid_client.CLIENT.realm_id


### PR DESCRIPTION
### Changes being made

Adding birthdate mappers to clients who use DOB.

### Context

in preparation to remove "birthdate" from profile scope in Prod env.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.