### PR TITLE
LRA clients: Add Licence Status scope mapping.

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/lra-dev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-dev/main.tf
@@ -39,3 +39,15 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper-
   add_to_access_token         = true
   add_to_userinfo             = true
 }
+
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "LICENCE-STATUS/MOA"          = var.LICENCE-STATUS.ROLES["MOA"].id
+    "LICENCE-STATUS/PRACTITIONER" = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
+    "LICENCE-STATUS/MD"           = var.LICENCE-STATUS.ROLES["MD"].id
+    "LICENCE-STATUS/RNP"          = var.LICENCE-STATUS.ROLES["RNP"].id
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/lra-sandbox/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-sandbox/main.tf
@@ -39,3 +39,15 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper-
   add_to_access_token         = true
   add_to_userinfo             = true
 }
+
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "LICENCE-STATUS/MOA"          = var.LICENCE-STATUS.ROLES["MOA"].id
+    "LICENCE-STATUS/PRACTITIONER" = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
+    "LICENCE-STATUS/MD"           = var.LICENCE-STATUS.ROLES["MD"].id
+    "LICENCE-STATUS/RNP"          = var.LICENCE-STATUS.ROLES["RNP"].id
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/lra-test/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-test/main.tf
@@ -39,3 +39,15 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper-
   add_to_access_token         = true
   add_to_userinfo             = true
 }
+
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "LICENCE-STATUS/MOA"          = var.LICENCE-STATUS.ROLES["MOA"].id
+    "LICENCE-STATUS/PRACTITIONER" = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
+    "LICENCE-STATUS/MD"           = var.LICENCE-STATUS.ROLES["MD"].id
+    "LICENCE-STATUS/RNP"          = var.LICENCE-STATUS.ROLES["RNP"].id
+  }
+}


### PR DESCRIPTION
### Changes being made

Add LICENCE-STATUS scope mapping to LRA clients so that LICENCE-STATUS is included in the tokens.

### Context

The LICENCE-STATUS protocol mapper was added, but we forgot to include the scope mappings. This caused an issue.

### Quality Check
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
