### PR TITLE
remove primary-care role from prime management group

### DIFF
--- a/keycloak-prod/realms/moh_applications/groups/prime-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/groups/prime-management/main.tf
@@ -11,7 +11,6 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
     var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-primary-care"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-prime-application"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,


### PR DESCRIPTION
### Changes being made

Removing `view-client-primary-care` from PRIME-MANAGEMENT group.

### Context

By mistake, `view-client-primary-care` role was added to PRIME-MANAGEMENT. It gives the members of the group more privileges than they should have.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
