### PR TITLE
add tbcm role and group

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
@@ -28,3 +28,13 @@ resource "keycloak_openid_client" "CLIENT" {
   web_origins = [
   ]
 }
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "admin" = {
+      "name" = "admin"
+    },
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/user-management-service/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management-service/main.tf
@@ -184,6 +184,9 @@ module "client-roles" {
     "view-client-tap" = {
       "name" = "view-client-tap"
     },
+    "view-client-tbcm" = {
+      "name" = "view-client-tbcm"
+    },
     "view-client-tpl" = {
       "name" = "view-client-tpl"
     },

--- a/keycloak-test/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management/main.tf
@@ -101,6 +101,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-client-swt"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-swt"].id,
     "USER-MANAGEMENT-SERVICE/view-client-swt_stg"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-swt_stg"].id,
     "USER-MANAGEMENT-SERVICE/view-client-tap"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-tap"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-tbcm"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-tbcm"].id,
     "USER-MANAGEMENT-SERVICE/view-client-tpl"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-tpl"].id,
     "USER-MANAGEMENT-SERVICE/view-client-webcaps"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-webcaps"].id,
     "USER-MANAGEMENT-SERVICE/view-clients"                          = var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,

--- a/keycloak-test/realms/moh_applications/groups.tf
+++ b/keycloak-test/realms/moh_applications/groups.tf
@@ -105,6 +105,11 @@ module "REGISTRIES-CONNECTIONS-TEAM" {
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
 }
 
+module "TBCM-MANAGEMENT" {
+  source                  = "./groups/tbcm-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
 module "TPL-MANAGEMENT" {
   source                  = "./groups/tpl-management"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE

--- a/keycloak-test/realms/moh_applications/groups/tbcm-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/tbcm-management/main.tf
@@ -1,0 +1,19 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "HSPP Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-tbcm"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-metrics"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/tbcm-management/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/tbcm-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/tbcm-management/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/tbcm-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/tbcm-management/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/tbcm-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made
On test environment: 
1. Add an `admin` role to TBCM client.
2.  Create a `tbcm-management` group. This group will allow for TBCM role assignment through UMC. 

### Context

TBCM client onboarding request

### Quality Check


- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 