### PR TITLE
create birthdate mapper for pidp

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/pidp-webapp/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pidp-webapp/main.tf
@@ -328,6 +328,13 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "given_names" {
   user_attribute  = "given_names"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "birthdate" {
+  claim_name     = "birthdate"
+  client_id      = keycloak_openid_client.CLIENT.id
+  name           = "birthdate"
+  user_attribute = "birthdate"
+  realm_id       = keycloak_openid_client.CLIENT.realm_id
+}
 resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider" {
   add_to_id_token  = false
   claim_name       = "identity_provider"


### PR DESCRIPTION
### Changes being made

Adding birthdate mapper to pidp-webapp on dev environment.

### Context

The reason for this PR is just to keep consistency between dev/test/prod environments. The birthdate has been already removed from the `profile` scope both on test and prod environments. Adding a custom birthdate mapper to the pidp-webapp client is a pre-work for removing the `birthdate` from the dev environment. 

The work was only done on test & prod before, as dev env is a sandbox for the Keycloak team and the affected clients were not actively using dev enviornment.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.