### PR TITLE
Create tbcm admin group

### DIFF
--- a/keycloak-test/realms/moh_applications/groups/tbcm-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/tbcm-management/main.tf
@@ -1,6 +1,6 @@
 resource "keycloak_group" "GROUP" {
   realm_id = "moh_applications"
-  name     = "HSPP Management"
+  name     = "TBCM Management"
 }
 
 resource "keycloak_group_roles" "GROUP_ROLES" {


### PR DESCRIPTION
### Changes being made

Fix TBCM admin group name

### Context

I've made a mistake and copied over the wrong group name which results in 409 - conflict error when applying the changes to terraform.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.