### PR TITLE
add view-client-tbcm role to manage-users realm role

### DIFF
--- a/keycloak-test/realms/moh_applications/realm-roles/manage-users/main.tf
+++ b/keycloak-test/realms/moh_applications/realm-roles/manage-users/main.tf
@@ -51,6 +51,7 @@ resource "keycloak_role" "REALM_ROLE" {
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-swt"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-swt_stg"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-tap"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-tbcm"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-tpl"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-webcaps"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,


### PR DESCRIPTION
### Changes being made

Updating `manage-users` realm role on test environment

### Context

updating the manage-users role will allow Keycloak developers to assign TBCM client roles.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 