### PR TITLE
HSPP: Add idir_mailboxOrgCode user attribute mapper.

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -50,6 +50,16 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "idir_displayName" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_attribute_protocol_mapper" "idir_mailboxOrgCode" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "idir_mailboxOrgCode"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "idir_mailboxOrgCode"
+  user_attribute  = "idir_mailboxOrgCode"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id


### PR DESCRIPTION
### Changes being made

Add a user attribute mapper for the HSPP client in TEST to add the idir_mailboxOrgCode to the ID token.

### Context

HSPP has requested this attribute. They will use it for authorization.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.