### PR TITLE
Changes requested by Kim Glidden

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -185,7 +185,6 @@ module "PIDP-WEBAPP" {
 module "PLR-LRA" {
   source  = "./clients/plr-lra"
   PLR_REV = module.PLR_REV
-  PLR_IAT = module.PLR_IAT
 }
 module "PLR-PRIMARY-CARE" {
   source   = "./clients/plr-primary-care"

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -185,6 +185,7 @@ module "PIDP-WEBAPP" {
 module "PLR-LRA" {
   source  = "./clients/plr-lra"
   PLR_REV = module.PLR_REV
+  PLR_IAT = module.PLR_IAT
 }
 module "PLR-PRIMARY-CARE" {
   source   = "./clients/plr-primary-care"

--- a/keycloak-test/realms/moh_applications/clients/plr-lra/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-lra/main.tf
@@ -45,7 +45,7 @@ module "service-account-roles" {
     "PLR_REV/CONSUMER" = {
       "client_id" = var.PLR_REV.CLIENT.id,
       "role_id"   = "CONSUMER"
-    },
+    }
     "PLR_IAT/CONSUMER" = {
       "client_id" = var.PLR_IAT.CLIENT.id,
       "role_id"   = "CONSUMER"
@@ -57,7 +57,7 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "PLR_REV/CONSUMER" = var.PLR_REV.ROLES["CONSUMER"].id,
+    "PLR_REV/CONSUMER" = var.PLR_REV.ROLES["CONSUMER"].id
     "PLR_IAT/CONSUMER" = var.PLR_IAT.ROLES["CONSUMER"].id
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/plr-lra/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-lra/main.tf
@@ -45,6 +45,10 @@ module "service-account-roles" {
     "PLR_REV/CONSUMER" = {
       "client_id" = var.PLR_REV.CLIENT.id,
       "role_id"   = "CONSUMER"
+    },
+    "PLR_IAT/CONSUMER" = {
+      "client_id" = var.PLR_IAT.CLIENT.id,
+      "role_id"   = "CONSUMER"
     }
   }
 }
@@ -53,6 +57,7 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "PLR_REV/CONSUMER" = var.PLR_REV.ROLES["CONSUMER"].id
+    "PLR_REV/CONSUMER" = var.PLR_REV.ROLES["CONSUMER"].id,
+    "PLR_IAT/CONSUMER" = var.PLR_IAT.ROLES["CONSUMER"].id
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/plr-lra/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-lra/variables.tf
@@ -1,1 +1,2 @@
 variable "PLR_REV" {}
+variable "PLR_IAT" {}


### PR DESCRIPTION
### Changes being made

Add PLR_IAT as an environment to existing PLR-LRA client.

### Context

Kim Glidden has requested we attempt to re-use the existing PLR-LRA client already in use with the PLR_REV environment.

### Quality Check

- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]
- [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [ ] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^2]

[^1]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^2]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
