### PR TITLE
add redirect url to test emcod client

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/emcod/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/emcod/main.tf
@@ -20,9 +20,9 @@ resource "keycloak_openid_client" "CLIENT" {
   use_refresh_tokens                  = true
   valid_redirect_uris = [
     "https://emcod-uat.vs.gov.bc.ca/*",
+    "https://emcod-test.vs.gov.bc.ca/*"
   ]
   web_origins = [
-    "https://emcod-uat.vs.gov.bc.ca",
     "+",
   ]
 }


### PR DESCRIPTION
### Changes being made

Adding redirect URL to EMCOD client on test environment. Removing the URL from web_origins section as `+` already includes this URL. (`+` includes all URLs specified in the valid_redirect_section)

### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.