### PR TITLE
add lra redirect urls

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/lra-dev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-dev/main.tf
@@ -22,6 +22,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "http://localhost:*",
     "https://localhost:*",
     "https://lra-dev.bchealthcloud.ca/*",
+    "https://main.dev.api.healthcarebc.ca/*"
   ]
   web_origins = [
   ]

--- a/keycloak-test/realms/moh_applications/clients/lra-sandbox/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-sandbox/main.tf
@@ -21,7 +21,8 @@ resource "keycloak_openid_client" "CLIENT" {
   valid_redirect_uris = [
     "http://localhost:*",
     "https://localhost:*",
-    "https://lra-sandbox.bchealthcloud.ca/*"
+    "https://lra-sandbox.bchealthcloud.ca/*",
+    "https://sbx1.dev.api.healthcarebc.ca/*"
   ]
   web_origins = [
   ]

--- a/keycloak-test/realms/moh_applications/clients/lra-test/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-test/main.tf
@@ -21,7 +21,8 @@ resource "keycloak_openid_client" "CLIENT" {
   valid_redirect_uris = [
     "http://localhost:*",
     "https://localhost:*",
-    "https://lra-test.bchealthcloud.ca/*"
+    "https://lra-test.bchealthcloud.ca/*",
+    "https://qa.test.api.healthcarebc.ca/*"
   ]
   web_origins = [
   ]


### PR DESCRIPTION
### Changes being made

Adding redirect URLs to LRA-Dev/Sandbox/Test clients on Keycloak test environment.

### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.
