### PR TITLE
Adding Metaspace IDIR attribute mappers

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/metaspace/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/metaspace/main.tf
@@ -48,6 +48,26 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "idir_company" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_attribute_protocol_mapper" "idir_displayName" {
+  add_to_id_token = true
+  add_to_userinfo = false
+  claim_name      = "idir_displayName"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "idir_displayName"
+  user_attribute  = "idir_displayName"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "idir_mailboxOrgCode" {
+  add_to_id_token = true
+  add_to_userinfo = false
+  claim_name      = "idir_mailboxOrgCode"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "idir_mailboxOrgCode"
+  user_attribute  = "idir_mailboxOrgCode"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
 resource "keycloak_openid_user_attribute_protocol_mapper" "bceid_business_legalName" {
   add_to_id_token = true
   add_to_userinfo = false


### PR DESCRIPTION
### Changes being made

Adding Metaspace mappers for idir_displayName + idir_mailboxOrgCode as per Hemant Kumar.

### Context

HLTH IDIR users need to be able to be identified for Metaspace authorization as they had been historically through SiteMinder's groups attribute.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)