### PR TITLE
fix wava client references

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/plr-wava/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-wava/main.tf
@@ -56,7 +56,7 @@ module "service-account-roles" {
       "role_id"   = "PRIMARY_SOURCE"
     }
     "PLR_IAT/CONSUMER" = {
-      "client_id" = var.PLR_REV.CLIENT.id,
+      "client_id" = var.PLR_IAT.CLIENT.id,
       "role_id"   = "CONSUMER"
     }
   }
@@ -68,7 +68,7 @@ module "scope-mappings" {
   roles = {
     "PLR_REV/PRIMARY_SOURCE" = var.PLR_REV.ROLES["PRIMARY_SOURCE"].id
     "PLR_REV/CONSUMER"       = var.PLR_REV.ROLES["CONSUMER"].id
-    "PLR_IAT/PRIMARY_SOURCE" = var.PLR_REV.ROLES["PRIMARY_SOURCE"].id
-    "PLR_IAT/CONSUMER"       = var.PLR_REV.ROLES["CONSUMER"].id
+    "PLR_IAT/PRIMARY_SOURCE" = var.PLR_IAT.ROLES["PRIMARY_SOURCE"].id
+    "PLR_IAT/CONSUMER"       = var.PLR_IAT.ROLES["CONSUMER"].id
   }
 }


### PR DESCRIPTION
### Changes being made

Changing the plr-wava client references. PLR_IAT role definition was pointing at PLR_REV client. 

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [ ] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
