### PR TITLE
add plr-iat role

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -200,6 +200,7 @@ module "PLR-PRIMARY-CARE" {
 module "PLR-PRP" {
   source  = "./clients/plr-prp"
   PLR_REV = module.PLR_REV
+  PLR_IAT = module.PLR_IAT
 }
 module "PLR-QA-CONSUMER" {
   source   = "./clients/plr-qa-consumer"

--- a/keycloak-test/realms/moh_applications/clients/plr-prp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-prp/main.tf
@@ -47,6 +47,10 @@ module "service-account-roles" {
       "client_id" = var.PLR_REV.CLIENT.id,
       "role_id"   = "CONSUMER"
     }
+    "PLR_IAT/CONSUMER" = {
+      "client_id" = var.PLR_IAT.CLIENT.id,
+      "role_id"   = "CONSUMER"
+    }
   }
 }
 module "scope-mappings" {
@@ -54,6 +58,7 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "PLR_REV/CONSUMER" = var.PLR_REV.ROLES["CONSUMER"].id
+    "PLR_REV/CONSUMER" = var.PLR_REV.ROLES["CONSUMER"].id,
+    "PLR_IAT/CONSUMER" = var.PLR_IAT.ROLES["CONSUMER"].id
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/plr-prp/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-prp/variables.tf
@@ -1,1 +1,2 @@
 variable "PLR_REV" {}
+variable "PLR_IAT" {}


### PR DESCRIPTION
### Changes being made

Allowing PLR-PRP service account to access PLR-IAT environment.

### Context

Joyce request - PRP is using the PLR-PRP client to reach the PLR-REV, would like to do the same with PLR-IAT. Change was confirmed with registries.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.