### PR TITLE
update roles and url for tbcm

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/tbcm/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/tbcm/main.tf
@@ -19,7 +19,8 @@ resource "keycloak_openid_client" "CLIENT" {
   standard_flow_enabled               = true
   use_refresh_tokens                  = true
   valid_redirect_uris = [
-    "https://d2xshb1uuel3zq.cloudfront.net/*"
+    "https://d2xshb1uuel3zq.cloudfront.net/*",
+    "https://moc.gov.bc.ca/*"
   ]
   web_origins = [
   ]
@@ -31,6 +32,9 @@ module "client-roles" {
   roles = {
     "admin" = {
       "name" = "admin"
+    },
+    "user" = {
+      "name" = "user"
     },
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
@@ -36,7 +36,7 @@ module "client-roles" {
     "admin" = {
       "name" = "admin"
     },
-        "user" = {
+    "user" = {
       "name" = "user"
     },
   }

--- a/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
@@ -36,5 +36,8 @@ module "client-roles" {
     "admin" = {
       "name" = "admin"
     },
+        "user" = {
+      "name" = "user"
+    },
   }
 }


### PR DESCRIPTION
### Changes being made
TBCM client: adding `user` role on test and prod environment. Adding redirect URL on Prod.

### Context
TBCM is preparing for PROD release. The cloudfront URL will be deleted when the changes are confirmed.

### Quality Check
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.