### PR TITLE
Migrating splunk client to prod

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients.tf
+++ b/keycloak-prod/realms/moh_applications/clients.tf
@@ -102,6 +102,9 @@ module "MIWT" {
 module "MOH-SERVICENOW" {
   source = "./clients/moh-servicenow"
 }
+module "MOH-SPLUNK" {
+  source = "./clients/moh-splunk"
+}
 module "MSPDIRECT-SERVICE" {
   source = "./clients/mspdirect-service"
 }

--- a/keycloak-prod/realms/moh_applications/clients/moh-splunk/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/moh-splunk/main.tf
@@ -1,0 +1,78 @@
+resource "keycloak_saml_client" "CLIENT" {
+  realm_id                  = "moh_applications"
+  client_id                 = "MOH-SPLUNK"
+  name                      = "MOH-SPLUNK"
+  description               = "This is a client to integrate with the OCIO's Splunk instance running against the HIVE. The HIVE is a centralized SIEM where we collect security related data to monitor and audit events occuring on MoH systems"
+  enabled                   = true
+  include_authn_statement   = true
+  sign_documents            = true
+  sign_assertions           = true
+  signature_algorithm       = "RSA_SHA256"
+  signature_key_name        = "KEY_ID"
+  canonicalization_method   = "EXCLUSIVE"
+  encrypt_assertions        = false
+  client_signature_required = false
+  force_post_binding        = true
+  front_channel_logout      = true
+  force_name_id_format      = false
+  name_id_format            = "username"
+  full_scope_allowed        = false
+
+  valid_redirect_uris = [
+    "https://siem.secops.gov.bc.ca/*"
+  ]
+  base_url = "https://siem.secops.gov.bc.ca/"
+
+  idp_initiated_sso_url_name          = "MOH-SPLUNK"
+  assertion_consumer_redirect_url     = "https://siem.secops.gov.bc.ca/health/saml/acs"
+  logout_service_redirect_binding_url = "https://siem.secops.gov.bc.ca/health/saml/logout"
+}
+
+resource "keycloak_role" "reportingadmin_role" {
+  realm_id    = keycloak_saml_client.CLIENT.realm_id
+  client_id   = keycloak_saml_client.CLIENT.id
+  name        = "reportingadmin"
+  description = "This is the role that maps to hlth_rw in the HIVE"
+}
+
+resource "keycloak_generic_client_role_mapper" "splunk_role_mapper" {
+  realm_id  = keycloak_saml_client.CLIENT.realm_id
+  client_id = keycloak_saml_client.CLIENT.id
+  role_id   = keycloak_role.reportingadmin_role.id
+}
+
+resource "keycloak_saml_user_attribute_protocol_mapper" "bceid_business_id" {
+  realm_id  = keycloak_saml_client.CLIENT.realm_id
+  client_id = keycloak_saml_client.CLIENT.id
+  name      = "bceid_business_id"
+
+  user_attribute             = "bceid_business_id"
+  saml_attribute_name        = "bceid_business_id"
+  saml_attribute_name_format = "Basic"
+  friendly_name              = "bceid_business_id"
+}
+
+resource "keycloak_saml_user_attribute_protocol_mapper" "idir_company" {
+  realm_id  = keycloak_saml_client.CLIENT.realm_id
+  client_id = keycloak_saml_client.CLIENT.id
+  name      = "idir_company"
+
+  user_attribute             = "idir_company"
+  saml_attribute_name        = "idir_company"
+  saml_attribute_name_format = "Basic"
+  friendly_name              = "idir_company"
+}
+
+resource "keycloak_generic_client_protocol_mapper" "role_list" {
+  realm_id        = keycloak_saml_client.CLIENT.realm_id
+  client_id       = keycloak_saml_client.CLIENT.id
+  name            = "role list"
+  protocol        = "saml"
+  protocol_mapper = "saml-role-list-mapper"
+  config = {
+    "attribute.name"       = "role"
+    "attribute.nameformat" = "Basic"
+    "attribute.value"      = "value"
+    "friendly.name"        = "role"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/moh-splunk/outputs.tf
+++ b/keycloak-prod/realms/moh_applications/clients/moh-splunk/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_saml_client.CLIENT
+}

--- a/keycloak-prod/realms/moh_applications/clients/moh-splunk/versions.tf
+++ b/keycloak-prod/realms/moh_applications/clients/moh-splunk/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Please include a short summary of the change.

### Context

What is the context for those changes? For example: particular role needs to be shown in token. Reference Azure Board task, if applicable.

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [ ] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [ ] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [ ] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [ ] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
