### PR TITLE
adding role mapper to include roles in userinfo

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
@@ -41,3 +41,15 @@ module "client-roles" {
     },
   }
 }
+resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper" {
+  add_to_access_token         = true
+  add_to_id_token             = true
+  add_to_userinfo             = true
+  claim_name                  = "resource_access.$${client_id}.roles"
+  claim_value_type            = "String"
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "TBCM"
+  multivalued                 = true
+  name                        = "client roles"
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}


### PR DESCRIPTION
### Changes being made

TBCM would like to have their application roles included in access and ID tokens, as well as /userinfo endpoint reply


### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.