### PR TITLE
add hardocoded role mapper

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
@@ -129,6 +129,13 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   session_note        = "identity_provider"
 }
 
+resource "keycloak_openid_hardcoded_role_protocol_mapper" "default-role-mapper" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  name      = "default-role-mapper"
+  role_id   = module.client-roles.ROLES["DefaultRole"].id
+}
+
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
@@ -153,6 +160,10 @@ module "client-roles" {
   client_id = keycloak_openid_client.CLIENT.id
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   roles = {
+    "Default_Role" = {
+      "name"        = "Default_Role"
+      "description" = ""
+    },
     "PC_Patient" = {
       "name"        = "PC_Patient"
       "description" = ""

--- a/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
@@ -133,7 +133,7 @@ resource "keycloak_openid_hardcoded_role_protocol_mapper" "default-role-mapper" 
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   name      = "default-role-mapper"
-  role_id   = module.client-roles.ROLES["DefaultRole"].id
+  role_id   = module.client-roles.ROLES["Default_Role"].id
 }
 
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {


### PR DESCRIPTION
### Changes being made

Adding hardcoded role mapper for PRIMARY-CARE on test.

### Context

PRIMARY-CARE wants to assign role by default to each user.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 