### PR TITLE
10539-remove explicitly defined defaulted values

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/hamis/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hamis/main.tf
@@ -29,33 +29,6 @@ module "payara-client" {
     "https://sts.healthbc.org/adfs/ls/*",
   ]
 }
-resource "keycloak_openid_user_session_note_protocol_mapper" "Client-Host" {
-  add_to_id_token  = true
-  claim_name       = "clientHost"
-  claim_value_type = "String"
-  client_id        = module.payara-client.CLIENT.id
-  name             = "Client Host"
-  realm_id         = module.payara-client.CLIENT.realm_id
-  session_note     = "clientHost"
-}
-resource "keycloak_openid_user_session_note_protocol_mapper" "Client-ID" {
-  add_to_id_token  = true
-  claim_name       = "clientId"
-  claim_value_type = "String"
-  client_id        = module.payara-client.CLIENT.id
-  name             = "Client ID"
-  realm_id         = module.payara-client.CLIENT.realm_id
-  session_note     = "clientId"
-}
-resource "keycloak_openid_user_session_note_protocol_mapper" "Client-IP-Address" {
-  add_to_id_token  = true
-  claim_name       = "clientAddress"
-  claim_value_type = "String"
-  client_id        = module.payara-client.CLIENT.id
-  name             = "Client IP Address"
-  realm_id         = module.payara-client.CLIENT.realm_id
-  session_note     = "clientAddress"
-}
 resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   add_to_id_token  = false
   claim_name       = "identity_provider"


### PR DESCRIPTION
### Changes being made

Removing explicitly defined default mappers

### Context

Mappers that are added by default are being unnecessarily defined and can be removed as this causes an issue in future Keycloak versions (>=v22)

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [x] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [x] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
