### PR TITLE
add custom mappers to pidp-service-account

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/pidp-service-account/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pidp-service-account/main.tf
@@ -24,6 +24,27 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
+resource "keycloak_openid_audience_protocol_mapper" "PIDP-SERVICE-aud-mapper" {
+  add_to_id_token          = false
+  client_id                = keycloak_openid_client.CLIENT.id
+  included_client_audience = "PIDP-SERVICE"
+  name                     = "PIDP-SERVICE aud mapper"
+  realm_id                 = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper" {
+  add_to_access_token         = true
+  add_to_id_token             = true
+  add_to_userinfo             = true
+  claim_name                  = "resource_access.PIDP-SERVICE.roles"
+  claim_value_type            = "String"
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "PIDP-SERVICE"
+  multivalued                 = true
+  name                        = "client roles"
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}
+
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-dev/realms/moh_applications/clients/pidp-service-account/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pidp-service-account/main.tf
@@ -39,7 +39,7 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   claim_name                  = "resource_access.PIDP-SERVICE.roles"
   claim_value_type            = "String"
   client_id                   = keycloak_openid_client.CLIENT.id
-  client_id_for_role_mappings = "PIDP-SERVICE"
+  client_id_for_role_mappings = "PIDP-SERVICE-ACCOUNT"
   multivalued                 = true
   name                        = "client roles"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id

--- a/keycloak-test/realms/moh_applications/clients/pidp-service-account/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/pidp-service-account/main.tf
@@ -24,6 +24,27 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
+resource "keycloak_openid_audience_protocol_mapper" "PIDP-SERVICE-aud-mapper" {
+  add_to_id_token          = false
+  client_id                = keycloak_openid_client.CLIENT.id
+  included_client_audience = "PIDP-SERVICE"
+  name                     = "PIDP-SERVICE aud mapper"
+  realm_id                 = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper" {
+  add_to_access_token         = true
+  add_to_id_token             = true
+  add_to_userinfo             = true
+  claim_name                  = "resource_access.PIDP-SERVICE.roles"
+  claim_value_type            = "String"
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "PIDP-SERVICE"
+  multivalued                 = true
+  name                        = "client roles"
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}
+
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-test/realms/moh_applications/clients/pidp-service-account/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/pidp-service-account/main.tf
@@ -39,7 +39,7 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   claim_name                  = "resource_access.PIDP-SERVICE.roles"
   claim_value_type            = "String"
   client_id                   = keycloak_openid_client.CLIENT.id
-  client_id_for_role_mappings = "PIDP-SERVICE"
+  client_id_for_role_mappings = "PIDP-SERVICE-ACCOUNT"
   multivalued                 = true
   name                        = "client roles"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id


### PR DESCRIPTION
### Changes being made

Adding `aud` and `resource_access` claim mappers to PIDP-SERVICE-ACCOUNT client on dev and test env

### Context

Request from James Hollinger - `service_account` role should show up under PIDP-SERVICE, although it's defined in PIDP-SERVICE-ACCOUNT client. Adding it directly to PIDP-SERVICE is not an option as it would show up in UMC, hence the mapper.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.