### PR TITLE
HCAP: added role in prod

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/hcap-fe/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hcap-fe/main.tf
@@ -44,6 +44,9 @@ module "client-roles" {
     "maximus" = {
       "name" = "maximus"
     },
+    "mhsu-employer" = {
+      "name" = "mhsu-employer"
+    },
     "ministry_of_health" = {
       "name" = "ministry_of_health"
     },


### PR DESCRIPTION
### Changes being made

Adding new role "mhsu-employer" to HCAP client in prod.

### Context

HCAP requires the new role "mhsu-employer" to be available in prod.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
