### PR TITLE
add localhost redirect to hsiar on test

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
@@ -19,6 +19,8 @@ resource "keycloak_openid_client" "CLIENT" {
   standard_flow_enabled               = true
   use_refresh_tokens                  = true
   valid_redirect_uris = [
+    "http://localhost:*",
+    "https://localhost:*",
     "https://uathicliip.healthideas.gov.bc.ca/*"
   ]
   web_origins = [


### PR DESCRIPTION
### Changes being made

Adding localhost as redirect URL to HSIAR client on test env

### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.
