### PR TITLE
Create pidp service account in prod

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/pidp-service-account/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pidp-service-account/main.tf
@@ -12,7 +12,7 @@ resource "keycloak_openid_client" "CLIENT" {
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
   implicit_flow_enabled               = false
-  name                                = ""
+  name                                = "PIDP-SERVICE-ACCOUNT"
   pkce_code_challenge_method          = ""
   realm_id                            = "moh_applications"
   service_accounts_enabled            = true

--- a/keycloak-dev/realms/moh_applications/clients/pidp-service-account/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pidp-service-account/main.tf
@@ -12,7 +12,7 @@ resource "keycloak_openid_client" "CLIENT" {
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
   implicit_flow_enabled               = false
-  name                                = "PIDP-SERVICE-ACCOUNT"
+  name                                = "PIDP Service Account"
   pkce_code_challenge_method          = ""
   realm_id                            = "moh_applications"
   service_accounts_enabled            = true

--- a/keycloak-prod/realms/moh_applications/clients.tf
+++ b/keycloak-prod/realms/moh_applications/clients.tf
@@ -125,6 +125,9 @@ module "PIDP-SERVICE" {
   source                  = "./clients/pidp-service"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
 }
+module "PIDP-SERVICE-ACCOUNT" {
+  source = "./clients/pidp-service-account"
+}
 module "PIDP-WEBAPP" {
   source       = "./clients/pidp-webapp"
   account      = module.account

--- a/keycloak-prod/realms/moh_applications/clients/pidp-service-account/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/pidp-service-account/main.tf
@@ -12,7 +12,7 @@ resource "keycloak_openid_client" "CLIENT" {
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
   implicit_flow_enabled               = false
-  name                                = ""
+  name                                = "PIDP-SERVICE-ACCOUNT"
   pkce_code_challenge_method          = ""
   realm_id                            = "moh_applications"
   service_accounts_enabled            = true

--- a/keycloak-prod/realms/moh_applications/clients/pidp-service-account/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/pidp-service-account/main.tf
@@ -12,7 +12,7 @@ resource "keycloak_openid_client" "CLIENT" {
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
   implicit_flow_enabled               = false
-  name                                = "PIDP-SERVICE-ACCOUNT"
+  name                                = "PIDP Service Account"
   pkce_code_challenge_method          = ""
   realm_id                            = "moh_applications"
   service_accounts_enabled            = true

--- a/keycloak-prod/realms/moh_applications/clients/pidp-service-account/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/pidp-service-account/main.tf
@@ -1,0 +1,73 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = "300"
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "PIDP-SERVICE-ACCOUNT"
+  consent_required                    = false
+  description                         = "Service account for Provider Identity Portal. Authorizes internal maintenance endpoint calls"
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = ""
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = true
+  standard_flow_enabled               = false
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+
+resource "keycloak_openid_audience_protocol_mapper" "PIDP-SERVICE-aud-mapper" {
+  add_to_id_token          = false
+  client_id                = keycloak_openid_client.CLIENT.id
+  included_client_audience = "PIDP-SERVICE"
+  name                     = "PIDP-SERVICE aud mapper"
+  realm_id                 = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper" {
+  add_to_access_token         = true
+  add_to_id_token             = true
+  add_to_userinfo             = true
+  claim_name                  = "resource_access.PIDP-SERVICE.roles"
+  claim_value_type            = "String"
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "PIDP-SERVICE-ACCOUNT"
+  multivalued                 = true
+  name                        = "client roles"
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}
+
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "service_account" = {
+      "name" = "service_account"
+    },
+  }
+}
+
+module "service-account-roles" {
+  source                  = "../../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {
+    "PIDP-SERVICE-ACCOUNT/service_account" = {
+      "client_id" = keycloak_openid_client.CLIENT.id,
+      "role_id"   = "service_account"
+    }
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/pidp-service-account/outputs.tf
+++ b/keycloak-prod/realms/moh_applications/clients/pidp-service-account/outputs.tf
@@ -1,0 +1,6 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}
+output "ROLES" {
+  value = module.client-roles.ROLES
+}

--- a/keycloak-prod/realms/moh_applications/clients/pidp-service-account/versions.tf
+++ b/keycloak-prod/realms/moh_applications/clients/pidp-service-account/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/pidp-service-account/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/pidp-service-account/main.tf
@@ -12,7 +12,7 @@ resource "keycloak_openid_client" "CLIENT" {
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
   implicit_flow_enabled               = false
-  name                                = ""
+  name                                = "PIDP-SERVICE-ACCOUNT"
   pkce_code_challenge_method          = ""
   realm_id                            = "moh_applications"
   service_accounts_enabled            = true

--- a/keycloak-test/realms/moh_applications/clients/pidp-service-account/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/pidp-service-account/main.tf
@@ -12,7 +12,7 @@ resource "keycloak_openid_client" "CLIENT" {
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
   implicit_flow_enabled               = false
-  name                                = "PIDP-SERVICE-ACCOUNT"
+  name                                = "PIDP Service Account"
   pkce_code_challenge_method          = ""
   realm_id                            = "moh_applications"
   service_accounts_enabled            = true


### PR DESCRIPTION
### Changes being made

Creating pidp-service-account client on Prod environment. Copy of client on dev/test environments. Used for internal api calls authorization.

Adding names to clients on dev/test.

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.