### PR TITLE
Adding PRP-WEB Dev Redirect URI

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/prp-web/main.tf
@@ -13,6 +13,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "http://localhost:*",
     "https://wonderful-cliff-0d1cec610.2.azurestaticapps.net/*",
     "https://devprp.hlth.gov.bc.ca/*",
+    "https://moh-dms-m-dev-as-prpcliip.azurewebsites.net/*",
     "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
     "https://login.microsoftonline.com/common/oauth2/v2.0/logout*",
   ]


### PR DESCRIPTION
### Changes being made

Adding https://moh-dms-m-dev-as-prpcliip.azurewebsites.net/* to PRP-WEB Dev client.

### Context

Adding PRP-WEB Dev Redirect URI as per Paul Kulpas.

### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)