### PR TITLE
PRIMARY-CARE: Add default role to PROD. Remove hardcoded role mapper …

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
@@ -137,6 +137,10 @@ module "client-roles" {
   client_id = keycloak_openid_client.CLIENT.id
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   roles = {
+    "Default_Role" = {
+      "name"        = "Default_Role"
+      "description" = ""
+    },
     "PC_Patient" = {
       "name"        = "PC_Patient"
       "description" = ""

--- a/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
@@ -131,13 +131,6 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   session_note        = "identity_provider"
 }
 
-resource "keycloak_openid_hardcoded_role_protocol_mapper" "default-role-mapper" {
-  realm_id  = keycloak_openid_client.CLIENT.realm_id
-  client_id = keycloak_openid_client.CLIENT.id
-  name      = "default-role-mapper"
-  role_id   = module.client-roles.ROLES["Default_Role"].id
-}
-
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id


### PR DESCRIPTION
### Changes being made

PRIMARY-CARE: Add default role to PROD. Remove hardcoded role mapper from TEST.

### Context

The Primary Care team is requesting this role. They'll assign in the UMC.

The hardcoded mapper in TEST didn't work the way they needed. They're checking the userinfo endpoint, and hardcoded roles don't show up there.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)