### PR TITLE
allow itsb to manage icy client

### DIFF
--- a/keycloak-test/realms/moh_applications/groups/itsb-access-team/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/itsb-access-team/main.tf
@@ -20,6 +20,7 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-gis"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hamis"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hscis"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-icy"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt_stg"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-dbaac-portal"].id,


### PR DESCRIPTION
### Changes being made

Add view-client-icy to ITSB admin group

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.
- [x] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply.