### PR TITLE
Added HSPP_Restricted_CVC role to Test and Prod.

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
@@ -89,7 +89,7 @@ module "client-roles" {
     "HSPP_Restricted_ACFT" = {
       "name" = "HSPP_Restricted_ACFT"
     },
-	"HSPP_Restricted_CVC" = {
+    "HSPP_Restricted_CVC" = {
       "name" = "HSPP_Restricted_CVC"
     },
     "HSPP_Restricted_ED" = {

--- a/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
@@ -89,6 +89,9 @@ module "client-roles" {
     "HSPP_Restricted_ACFT" = {
       "name" = "HSPP_Restricted_ACFT"
     },
+	"HSPP_Restricted_CVC" = {
+      "name" = "HSPP_Restricted_CVC"
+    },
     "HSPP_Restricted_ED" = {
       "name" = "HSPP_Restricted_ED"
     },

--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -104,7 +104,7 @@ module "client-roles" {
     "HSPP_Restricted_ACFT" = {
       "name" = "HSPP_Restricted_ACFT"
     },
-	"HSPP_Restricted_CVC" = {
+    "HSPP_Restricted_CVC" = {
       "name" = "HSPP_Restricted_CVC"
     },
     "HSPP_Restricted_ED" = {

--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -104,6 +104,9 @@ module "client-roles" {
     "HSPP_Restricted_ACFT" = {
       "name" = "HSPP_Restricted_ACFT"
     },
+	"HSPP_Restricted_CVC" = {
+      "name" = "HSPP_Restricted_CVC"
+    },
     "HSPP_Restricted_ED" = {
       "name" = "HSPP_Restricted_ED"
     },


### PR DESCRIPTION
### Changes being made

Added HSPP_Restricted_CVC role to HSPP in Test and Prod.

### Context

Requested by DMS.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
