### PR TITLE
assign plr-iat role

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -210,6 +210,7 @@ module "PLR-PRIMARY-CARE" {
 module "PLR-PRP" {
   source  = "./clients/plr-prp"
   PLR_REV = module.PLR_REV
+  PLR_IAT = module.PLR_IAT
 }
 module "PLR-QA-CONSUMER" {
   source   = "./clients/plr-qa-consumer"

--- a/keycloak-test/realms/moh_applications/clients/plr-prp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-prp/main.tf
@@ -46,6 +46,10 @@ module "service-account-roles" {
     "PLR_REV/CONSUMER" = {
       "client_id" = var.PLR_REV.CLIENT.id,
       "role_id"   = "CONSUMER"
+    },
+    "PLR_IAT/CONSUMER" = {
+      "client_id" = var.PLR_IAT.CLIENT.id,
+      "role_id"   = "CONSUMER"
     }
   }
 }
@@ -54,6 +58,7 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "PLR_REV/CONSUMER" = var.PLR_REV.ROLES["CONSUMER"].id
+    "PLR_REV/CONSUMER" = var.PLR_REV.ROLES["CONSUMER"].id,
+    "PLR_IAT/CONSUMER" = var.PLR_IAT.ROLES["CONSUMER"].id
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/plr-prp/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-prp/variables.tf
@@ -1,1 +1,2 @@
 variable "PLR_REV" {}
+variable "PLR_IAT" {}


### PR DESCRIPTION
### Changes being made

Assigning CONSUMER role to plr-prp client on Keycloak Test environment.

### Context

Kushwinder (PLR) confirmed that org-id will be the same across REV and IAT environments.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.