### PR TITLE
Added client for CMDB test

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -16,6 +16,9 @@ module "BCHCIM" {
 module "CONNECT" {
   source = "./clients/connect"
 }
+module "CMDB" {
+  source = "./clients/cmdb"
+}
 module "DEMO-CLIENT" {
   source = "./clients/demo-client"
 }

--- a/keycloak-test/realms/moh_applications/clients/cmdb/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/cmdb/main.tf
@@ -1,0 +1,34 @@
+module "payara-client" {
+  source                             = "../../../../../modules/payara-client"
+  base_url                           = "https://cmdbt.hlth.gov.bc.ca"
+  client_id                          = "CMDB"
+  client_name                        = "CMDB"
+  client_role_mapper_add_to_id_token = false
+  client_role_mapper_add_to_userinfo = false
+  description                        = "The Configuration Management Database (CMDB) is used to store information on MoH software assets"
+  service_accounts_enabled = false
+  valid_redirect_uris = [
+    "https://cmdbt.hlth.gov.bc.ca/*",
+    "http://localhost:8444/*"
+  ]
+}
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = module.payara-client.CLIENT.realm_id
+  client_id = module.payara-client.CLIENT.id
+  default_scopes = [
+    "profile",
+    "email",
+    "roles",
+    "web-origins"
+  ]
+}
+
+resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
+  add_to_id_token  = false
+  claim_name       = "identity_provider"
+  claim_value_type = "String"
+  client_id        = module.payara-client.CLIENT.id
+  name             = "IDP"
+  realm_id         = module.payara-client.CLIENT.realm_id
+  session_note     = "identity_provider"
+}

--- a/keycloak-test/realms/moh_applications/clients/cmdb/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/cmdb/main.tf
@@ -1,25 +1,27 @@
-module "payara-client" {
-  source                             = "../../../../../modules/payara-client"
-  base_url                           = "https://cmdbt.hlth.gov.bc.ca"
-  client_id                          = "CMDB"
-  client_name                        = "CMDB"
-  client_role_mapper_add_to_id_token = false
-  client_role_mapper_add_to_userinfo = false
-  description                        = "The Configuration Management Database (CMDB) is used to store information on MoH software assets"
-  service_accounts_enabled           = false
+resource "keycloak_openid_client" "CMDB" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "CMDB"
+  consent_required                    = false
+  description                         = "Configuration Management Database (CMDB) is a database for with a COTS front end for tracking MoH Software Assets"
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "CMDB"
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = true
   valid_redirect_uris = [
-    "https://cmdbt.hlth.gov.bc.ca/*",
-    "http://localhost:8444/*"
+    "https://localhost:8444/*",
+    "https://cmdbt.hlth.gov.bc.ca/*"
   ]
-}
-resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
-  realm_id  = module.payara-client.CLIENT.realm_id
-  client_id = module.payara-client.CLIENT.id
-  default_scopes = [
-    "profile",
-    "email",
-    "roles",
-    "web-origins"
+  web_origins = [
   ]
 }
 

--- a/keycloak-test/realms/moh_applications/clients/cmdb/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/cmdb/main.tf
@@ -24,13 +24,3 @@ resource "keycloak_openid_client" "CMDB" {
   web_origins = [
   ]
 }
-
-resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
-  add_to_id_token  = false
-  claim_name       = "identity_provider"
-  claim_value_type = "String"
-  client_id        = module.payara-client.CLIENT.id
-  name             = "IDP"
-  realm_id         = module.payara-client.CLIENT.realm_id
-  session_note     = "identity_provider"
-}

--- a/keycloak-test/realms/moh_applications/clients/cmdb/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/cmdb/main.tf
@@ -6,7 +6,7 @@ module "payara-client" {
   client_role_mapper_add_to_id_token = false
   client_role_mapper_add_to_userinfo = false
   description                        = "The Configuration Management Database (CMDB) is used to store information on MoH software assets"
-  service_accounts_enabled = false
+  service_accounts_enabled           = false
   valid_redirect_uris = [
     "https://cmdbt.hlth.gov.bc.ca/*",
     "http://localhost:8444/*"

--- a/keycloak-test/realms/moh_applications/clients/cmdb/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/cmdb/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = module.payara-client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/cmdb/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/cmdb/outputs.tf
@@ -1,3 +1,1 @@
-output "CLIENT" {
-  value = module.payara-client.CLIENT
-}
+

--- a/keycloak-test/realms/moh_applications/clients/cmdb/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/cmdb/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

This change includes the addition of the new client configuration for CMDB
### Context

This is needed for migrating CMDB away from LDAP
### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [ ] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
