### PR TITLE
add hspp role and persist gis url

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/gis/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/gis/main.tf
@@ -19,5 +19,6 @@ module "payara-client" {
     "https://gis.hlth.gov.bc.ca/*",
     "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi*",
     "https://sts.healthbc.org/adfs/ls/*",
+    "https://gis.ynr9ed-prod.nimbus.cloud.gov.bc.ca/gis/*"
   ]
 }

--- a/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
@@ -104,5 +104,8 @@ module "client-roles" {
     "HSPP_Restricted_UPCC" = {
       "name" = "HSPP_Restricted_UPCC"
     },
+    "HSPP_Restricted_MHAD" = {
+      "name" = "HSPP_Restricted_MHAD"
+    },
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -119,5 +119,8 @@ module "client-roles" {
     "HSPP_Restricted_UPCC" = {
       "name" = "HSPP_Restricted_UPCC"
     },
+    "HSPP_Restricted_MHAD" = {
+      "name" = "HSPP_Restricted_MHAD"
+    },
   }
 }


### PR DESCRIPTION
### Changes being made

Add a role to HSPP on test and prod env. Add GIS redirect url on Prod, to persist the manual changes.

### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.