### PR TITLE
Update HSPP Redirect URIs in Test

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -25,7 +25,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://devhspp.healthideas.gov.bc.ca/*",
     "https://devsecure.healthideas.gov.bc.ca/*",
     "https://moh-dms-m-sit-as-hspp.azurewebsites.net/*",
-    "https://sithspp.healthideas.gov.bc.ca/*",
+    "https://sithspp.hlth.gov.bc.ca/*",
   ]
   web_origins = [
   ]


### PR DESCRIPTION


### Changes being made

Replace sithspp.healthideas.gov.bc.ca with sithspp.hlth.gov.bc.ca in Test.

### Context

Change requested by HSIAR via AM inbox request.

### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
