### PR TITLE
create alr prod client and management groups

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients.tf
+++ b/keycloak-prod/realms/moh_applications/clients.tf
@@ -4,6 +4,9 @@ module "account" {
 module "realm-management" {
   source = "../../../modules/realm-management"
 }
+module "ALR" {
+  source = "./clients/alr"
+}
 module "BCER-CP" {
   source = "./clients/bcer-cp"
 }

--- a/keycloak-prod/realms/moh_applications/clients/alr/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/alr/main.tf
@@ -1,0 +1,86 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = "300"
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "ALR"
+  consent_required                    = false
+  description                         = "The ALR system supports in licensing ALR facilities and maintaining an up-to-date record of inspection status."
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "Assisted Living Registry"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = false
+  valid_redirect_uris = [
+    "https://bcministryofhealth-environmentalh2.lightning.force.com/*"
+  ]
+  web_origins = [
+  ]
+}
+
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "email",
+    "profile",
+    "roles",
+    "web-origins"
+  ]
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper-ALR" {
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "ALR"
+  name                        = "ALR Role Mapper"
+  claim_name                  = "roles"
+  multivalued                 = true
+  claim_value_type            = "String"
+  add_to_id_token             = true
+  add_to_access_token         = true
+  add_to_userinfo             = true
+}
+
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "ALR_Admin_Clerk" : {
+      "name" : "ALR_Admin_Clerk",
+      "description" : ""
+    },
+    "ALR_Data_Analyst" : {
+      "name" : "ALR_Data_Analyst",
+      "description" : ""
+    },
+    "ALR_Investigator" : {
+      "name" : "ALR_Investigator",
+      "description" : ""
+    },
+    "ALR_Registrar" : {
+      "name" : "ALR_Registrar",
+      "description" : ""
+    },
+    "ALR_Leadership" : {
+      "name" : "ALR_Leadership",
+      "description" : ""
+    },
+    "ALR_Ops_Support_1" : {
+      "name" : "ALR_Ops_Support_1",
+      "description" : ""
+    },
+    "ALR_Ops_Support_2" : {
+      "name" : "ALR_Ops_Support_2",
+      "description" : ""
+    }
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/alr/outputs.tf
+++ b/keycloak-prod/realms/moh_applications/clients/alr/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-prod/realms/moh_applications/clients/alr/versions.tf
+++ b/keycloak-prod/realms/moh_applications/clients/alr/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/user-management-service/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/user-management-service/main.tf
@@ -46,6 +46,9 @@ module "client-roles" {
     "manage-user-roles" = {
       "name" = "manage-user-roles"
     },
+    "view-client-alr" = {
+      "name" = "view-client-alr"
+    },
     "view-client-bcer-cp" = {
       "name" = "view-client-bcer-cp"
     },

--- a/keycloak-prod/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/user-management/main.tf
@@ -56,6 +56,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/manage-org"                            = var.USER-MANAGEMENT-SERVICE.ROLES["manage-org"].id,
     "USER-MANAGEMENT-SERVICE/manage-own-groups"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-roles"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-alr"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-alr"].id,
     "USER-MANAGEMENT-SERVICE/view-client-bcer-cp"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
     "USER-MANAGEMENT-SERVICE/view-client-dmft-webappp"              = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-dmft-webapp"].id,
     "USER-MANAGEMENT-SERVICE/view-client-eacl"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl"].id,

--- a/keycloak-prod/realms/moh_applications/groups.tf
+++ b/keycloak-prod/realms/moh_applications/groups.tf
@@ -1,3 +1,8 @@
+module "ALR-MANAGEMENT" {
+  source                  = "./groups/alr-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
 module "CGI-DBA" {
   source = "./groups/cgi-dba"
   HEM    = module.HEM

--- a/keycloak-prod/realms/moh_applications/groups/alr-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/groups/alr-management/main.tf
@@ -1,0 +1,18 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "ALR Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-alr"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-prod/realms/moh_applications/groups/alr-management/output.tf
+++ b/keycloak-prod/realms/moh_applications/groups/alr-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-prod/realms/moh_applications/groups/alr-management/variables.tf
+++ b/keycloak-prod/realms/moh_applications/groups/alr-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-prod/realms/moh_applications/groups/alr-management/versions.tf
+++ b/keycloak-prod/realms/moh_applications/groups/alr-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/user-management-service/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management-service/main.tf
@@ -46,6 +46,9 @@ module "client-roles" {
     "manage-user-roles" = {
       "name" = "manage-user-roles"
     },
+    "view-client-alr" = {
+      "name" = "view-client-alr"
+    },
     "view-client-bcer-cp" = {
       "name" = "view-client-bcer-cp"
     },

--- a/keycloak-test/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management/main.tf
@@ -56,6 +56,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/manage-org"                            = var.USER-MANAGEMENT-SERVICE.ROLES["manage-org"].id,
     "USER-MANAGEMENT-SERVICE/manage-own-groups"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-roles"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-alr"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-alr"].id,
     "USER-MANAGEMENT-SERVICE/view-client-bcer-cp"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
     "USER-MANAGEMENT-SERVICE/view-client-dhiper"                    = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-dhiper"].id,
     "USER-MANAGEMENT-SERVICE/view-client-dmft-webappp"              = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-dmft-webapp"].id,

--- a/keycloak-test/realms/moh_applications/groups.tf
+++ b/keycloak-test/realms/moh_applications/groups.tf
@@ -1,3 +1,8 @@
+module "ALR-MANAGEMENT" {
+  source                  = "./groups/alr-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
 module "CGI-DEVELOPER" {
   source                  = "./groups/cgi-developer"
   CGI-APPLICATION-SUPPORT = module.CGI-APPLICATION-SUPPORT

--- a/keycloak-test/realms/moh_applications/groups/alr-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/alr-management/main.tf
@@ -1,0 +1,18 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "ALR Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-alr"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/alr-management/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/alr-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/alr-management/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/alr-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/alr-management/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/alr-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Promoting ALR client to Production environment. Crating ALR-MANAGEMENT group on Test and Production environment.

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.
- [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [ ] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply.
