### PR TITLE
fix cors ad redirects for usam

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/usam/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/usam/main.tf
@@ -21,8 +21,10 @@ resource "keycloak_openid_client" "CLIENT" {
   valid_redirect_uris = [
     "http://localhost:*",
     "https://localhost:*",
+    "https://localhost:7154/usam",
   ]
   web_origins = [
+    "+"
   ]
 }
 


### PR DESCRIPTION
### Changes being made

Updating Web Origins - USAM client is having CORS issues.

### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.