### PR TITLE
DEV: Configure Terraform to use a service account in the master realm

### DIFF
--- a/keycloak-dev/main.tf
+++ b/keycloak-dev/main.tf
@@ -12,7 +12,7 @@ module "moh_applications" {
 }
 
 provider "keycloak" {
-  realm         = "moh_applications"
+  realm         = "master"
   client_id     = var.client_id
   client_secret = var.client_secret
   url           = var.keycloak_url

--- a/keycloak-dev/realms/moh_applications/clients/terraform/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/terraform/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "terraform"
   consent_required                    = false
-  description                         = ""
+  description                         = "Deprecated client. To be deleted."
   direct_access_grants_enabled        = false
   enabled                             = true
   frontchannel_logout_enabled         = false


### PR DESCRIPTION
### Changes being made

DEV: Configure Terraform to use a service account in the master realm instead of moh_applications so that it can manage clients in multiple realms.

### Context

This will allow Terraform to manage clients in multiple realms. We would like to use Terraform to manage clients in the new "applications" realm.