### PR TITLE
TEST: Configure Terraform to use a service account in the master real…

### DIFF
--- a/keycloak-test/main.tf
+++ b/keycloak-test/main.tf
@@ -12,7 +12,7 @@ module "moh_applications" {
 }
 
 provider "keycloak" {
-  realm         = "moh_applications"
+  realm         = "master"
   client_id     = var.client_id
   client_secret = var.client_secret
   url           = var.keycloak_url

--- a/keycloak-test/realms/moh_applications/clients/terraform/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/terraform/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "terraform"
   consent_required                    = false
-  description                         = ""
+  description                         = "Deprecated client. To be deleted."
   direct_access_grants_enabled        = false
   enabled                             = true
   frontchannel_logout_enabled         = false


### PR DESCRIPTION
TEST: Configure Terraform to use a service account in the master realm instead of moh_applications.