### PR TITLE
create-edrd-client

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -43,6 +43,9 @@ module "EACL" {
 module "EACL_STG" {
   source = "./clients/eacl_stg"
 }
+module "EDRD" {
+  source = "./clients/edrd"
+}
 module "EHPR" {
   source = "./clients/ehpr"
 }

--- a/keycloak-test/realms/moh_applications/clients/edrd/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/edrd/main.tf
@@ -1,0 +1,52 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = "300"
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "EDRD"
+  consent_required                    = false
+  description                         = "Expensive Drugs for Rare Disease"
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "EDRD"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = false
+  valid_redirect_uris = [
+    "https://bchealth--edrduat.sandbox.my.salesforce.com/*",
+    "https://bchealth--edrduat.sandbox.my.site.com/*",
+  ]
+  web_origins = [
+  ]
+}
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "EDRD_Admin" = {
+      "name" = "EDRD_Admin"
+    },
+    "EDRD_Staff" = {
+      "name" = "EDRD_Staff"
+    },
+  }
+}
+resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper" {
+  add_to_access_token         = true
+  add_to_id_token             = true
+  add_to_userinfo             = true
+  claim_name                  = "roles"
+  claim_value_type            = "String"
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "EDRD"
+  multivalued                 = true
+  name                        = "client roles"
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-test/realms/moh_applications/clients/edrd/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/edrd/outputs.tf
@@ -1,0 +1,6 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}
+output "ROLES" {
+  value = module.client-roles.ROLES
+}

--- a/keycloak-test/realms/moh_applications/clients/edrd/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/edrd/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/usam/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/usam/main.tf
@@ -23,7 +23,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://localhost:*",
   ]
   web_origins = [
-    "*"
+    "+"
   ]
 }
 

--- a/keycloak-test/realms/moh_applications/clients/usam/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/usam/main.tf
@@ -23,6 +23,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://localhost:*",
   ]
   web_origins = [
+    "*"
   ]
 }
 


### PR DESCRIPTION
### Changes being made

Creating EDRD Test client.

### Context

Basic configuration, diverged from the meeting. 

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [ ] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
