### PR TITLE
configure health-ideas client and management groups

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -96,6 +96,9 @@ module "HCIM_VIHA" {
 module "HDPBC" {
   source = "./clients/hdpbc"
 }
+module "HEALTH-IDEAS" {
+  source = "./clients/health-ideas"
+}
 module "HEM" {
   source = "./clients/hem"
 }

--- a/keycloak-test/realms/moh_applications/clients/health-ideas/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/health-ideas/main.tf
@@ -1,0 +1,66 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "HEALTH-IDEAS"
+  consent_required                    = false
+  description                         = "HealthIdeas Reporting Application"
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "HEALTH-IDEAS"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+    "http://localhost:*",
+    "https://localhost:*",
+    "https://devsecure.healthideas.gov.bc.ca/*",
+    "https://uatsecure.healthideas.gov.bc.ca/*"
+  ]
+  web_origins = [
+
+  ]
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper" {
+  add_to_access_token         = true
+  add_to_id_token             = true
+  claim_name                  = "roles"
+  claim_value_type            = "String"
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "HI"
+  multivalued                 = true
+  name                        = "client roles"
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}
+
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "REPORTS_ADMIN_DEV" = {
+      "name" = "REPORTS_ADMIN_DEV"
+    },
+    "REPORTS_ADMIN_UAT" = {
+      "name" = "REPORTS_ADMIN_UAT"
+    }
+  }
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "idir_username" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "idir_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "idir_username"
+  user_attribute  = "idir_username"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-test/realms/moh_applications/clients/health-ideas/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/health-ideas/main.tf
@@ -35,7 +35,7 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   claim_name                  = "roles"
   claim_value_type            = "String"
   client_id                   = keycloak_openid_client.CLIENT.id
-  client_id_for_role_mappings = "HI"
+  client_id_for_role_mappings = "HEALTH-IDEAS"
   multivalued                 = true
   name                        = "client roles"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id

--- a/keycloak-test/realms/moh_applications/clients/health-ideas/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/health-ideas/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/health-ideas/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/health-ideas/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/user-management-service/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management-service/main.tf
@@ -103,6 +103,9 @@ module "client-roles" {
     "view-client-hcimweb_huat" = {
       "name" = "view-client-hcimweb_huat"
     },
+    "view-client-health-ideas" = {
+      "name" = "view-client-health-ideas"
+    }
     "view-client-hem" = {
       "name" = "view-client-hem"
     },

--- a/keycloak-test/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management/main.tf
@@ -73,6 +73,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-client-hcimweb_hs1"               = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_hs1"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hcimweb_hsit"              = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_hsit"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hcimweb_huat"              = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_huat"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-health-ideas"              = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-health-ideas"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hem"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hem"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hscis"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hscis"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hsiar"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hsiar"].id,

--- a/keycloak-test/realms/moh_applications/groups.tf
+++ b/keycloak-test/realms/moh_applications/groups.tf
@@ -52,6 +52,11 @@ module "EMCOD-ACCESS-TEAM" {
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
 }
 
+module "HEALTH-IDEAS-MANAGEMENT" {
+  source                  = "./groups/health-ideas-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
 module "HIBC-ACCESS-MANAGEMENT" {
   source                  = "./groups/hibc-access-management"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE

--- a/keycloak-test/realms/moh_applications/groups/health-ideas-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/health-ideas-management/main.tf
@@ -1,0 +1,22 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "Health-IDEAS Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-health-ideas"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-metrics"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/health-ideas-management/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/health-ideas-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/health-ideas-management/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/health-ideas-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/health-ideas-management/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/health-ideas-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/realm-roles/manage-users/main.tf
+++ b/keycloak-test/realms/moh_applications/realm-roles/manage-users/main.tf
@@ -23,6 +23,7 @@ resource "keycloak_role" "REALM_ROLE" {
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_hs1"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_hsit"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_huat"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-health-ideas"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hem"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hscis"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hsiar"].id,


### PR DESCRIPTION
### Changes being made

Creating Health Ideas client on Test and management groups for it.

### Context

New client onboarding. 'terraform apply' will need to be re-run since composite role is being updated.

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [x] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
