### PR TITLE
Add Panorama to TEST.

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -189,6 +189,9 @@ module "MSPDIRECT-WEB-UAT" {
 module "ORGANIZATIONS-API" {
   source = "./clients/organizations-api"
 }
+module "PANORAMA" {
+  source                  = "./clients/panorama"
+}
 module "PIDP-SERVICE" {
   source                  = "./clients/pidp-service"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -190,7 +190,7 @@ module "ORGANIZATIONS-API" {
   source = "./clients/organizations-api"
 }
 module "PANORAMA" {
-  source                  = "./clients/panorama"
+  source = "./clients/panorama"
 }
 module "PIDP-SERVICE" {
   source                  = "./clients/pidp-service"

--- a/keycloak-test/realms/moh_applications/clients/panorama/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/panorama/main.tf
@@ -20,7 +20,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "*",
   ]
   web_origins = [
-    "+",
+    "",
   ]
 }
 

--- a/keycloak-test/realms/moh_applications/clients/panorama/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/panorama/main.tf
@@ -5,7 +5,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type    = "client-secret"
   client_id                    = "PANORAMA"
   consent_required             = false
-  description                  = ""
+  description                  = "An eHealth system that allows authorized public health care providers to document and securely store all public health services and care programs in BC and Yukon."
   direct_access_grants_enabled = false
   enabled                      = true
   frontchannel_logout_enabled  = false

--- a/keycloak-test/realms/moh_applications/clients/panorama/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/panorama/main.tf
@@ -1,0 +1,35 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan        = ""
+  access_type                  = "CONFIDENTIAL"
+  base_url                     = ""
+  client_authenticator_type    = "client-secret"
+  client_id                    = "PANORAMA"
+  consent_required             = false
+  description                  = ""
+  direct_access_grants_enabled = false
+  enabled                      = true
+  frontchannel_logout_enabled  = false
+  full_scope_allowed           = false
+  implicit_flow_enabled        = false
+  name                         = "Panorama"
+  pkce_code_challenge_method   = ""
+  realm_id                     = "moh_applications"
+  service_accounts_enabled     = false
+  standard_flow_enabled        = true
+  valid_redirect_uris = [
+    "*",
+  ]
+  web_origins = [
+    "+",
+  ]
+}
+
+resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider" {
+  add_to_id_token  = true
+  claim_name       = "identity_provider"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "identity_provider"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "identity_provider"
+}

--- a/keycloak-test/realms/moh_applications/clients/panorama/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/panorama/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/panorama/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/panorama/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Please include a short summary of the change.

### Context

What is the context for those changes? For example: particular role needs to be shown in token. Reference Azure Board task, if applicable.

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [x] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
