### PR TITLE
PANAORAMA TEST: Fix web-origins value. Cannot be empty string.

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/panorama/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/panorama/main.tf
@@ -20,7 +20,6 @@ resource "keycloak_openid_client" "CLIENT" {
     "*",
   ]
   web_origins = [
-    "",
   ]
 }
 


### PR DESCRIPTION
### Changes being made

Fix web-origins value. Cannot be empty string.

### Context

The previous PR `apply` failed due to this mistake, so this will include adding the Panorama client to TEST.
