### PR TITLE
create plr-regadmin service account on prod

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients.tf
+++ b/keycloak-prod/realms/moh_applications/clients.tf
@@ -150,6 +150,10 @@ module "PLR-SHOPPERS" {
   source = "./clients/plr-shoppers"
   PLR    = module.PLR
 }
+module "PLR-REGADMIN" {
+  source = "./clients/plr-regadmin"
+  PLR    = module.PLR
+}
 module "PPM-API-CGI-BC30550160" {
   source = "./clients/ppm-api-cgi-BC30550160"
 }

--- a/keycloak-prod/realms/moh_applications/clients/plr-regadmin/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/plr-regadmin/main.tf
@@ -53,6 +53,6 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "PLR/REG_ADMIN"  = var.PLR.ROLES["REG_ADMIN"].id
+    "PLR/REG_ADMIN" = var.PLR.ROLES["REG_ADMIN"].id
   }
 }

--- a/keycloak-prod/realms/moh_applications/clients/plr-regadmin/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/plr-regadmin/main.tf
@@ -1,0 +1,58 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = "18000"
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "PLR-REGADMIN"
+  consent_required                    = false
+  description                         = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources. This client will be used to generate access tokens for the internal PLR team with the PLR REG_ADMIN role."
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "PLR-REGADMIN"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = true
+  standard_flow_enabled               = false
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+resource "keycloak_openid_hardcoded_claim_protocol_mapper" "orgId" {
+  add_to_access_token = true
+  add_to_id_token     = true
+  add_to_userinfo     = true
+  claim_name          = "orgId"
+  claim_value         = "00000010"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "orgId"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+module "service-account-roles" {
+  source                  = "../../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {
+    "PLR/REG_ADMIN" = {
+      "client_id" = var.PLR.CLIENT.id,
+      "role_id"   = "REG_ADMIN"
+    }
+  }
+}
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "PLR/REG_ADMIN"  = var.PLR.ROLES["REG_ADMIN"].id
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/plr-regadmin/outputs.tf
+++ b/keycloak-prod/realms/moh_applications/clients/plr-regadmin/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-prod/realms/moh_applications/clients/plr-regadmin/variables.tf
+++ b/keycloak-prod/realms/moh_applications/clients/plr-regadmin/variables.tf
@@ -1,0 +1,1 @@
+variable "PLR" {}

--- a/keycloak-prod/realms/moh_applications/clients/plr-regadmin/versions.tf
+++ b/keycloak-prod/realms/moh_applications/clients/plr-regadmin/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Create service account for PLR on Prod with REGADMIN role.

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided.
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 
