### PR TITLE
create plr-lra-regadmin client on test

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -209,6 +209,11 @@ module "PLR-LRA" {
   PLR_REV = module.PLR_REV
   PLR_IAT = module.PLR_IAT
 }
+module "PLR-LRA-REGADMIN" {
+  source  = "./clients/plr-lra-regadmin"
+  PLR_REV = module.PLR_REV
+  PLR_IAT = module.PLR_IAT
+}
 module "PLR-PRIMARY-CARE" {
   source   = "./clients/plr-primary-care"
   PLR_IAT  = module.PLR_IAT

--- a/keycloak-test/realms/moh_applications/clients/plr-lra-regadmin/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-lra-regadmin/main.tf
@@ -1,0 +1,63 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = "18000"
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "PLR-LRA-REGADMIN"
+  consent_required                    = false
+  description                         = "This service account client will allow LRA to access PLR with REGADMIN permissions"
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "PLR-LRA-REGADMIN"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = true
+  standard_flow_enabled               = false
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+resource "keycloak_openid_hardcoded_claim_protocol_mapper" "orgId" {
+  add_to_access_token = true
+  add_to_id_token     = true
+  add_to_userinfo     = true
+  claim_name          = "orgId"
+  claim_value         = "00025902"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "orgId"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+module "service-account-roles" {
+  source                  = "../../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {
+    "PLR_REV/REG_ADMIN" = {
+      "client_id" = var.PLR_REV.CLIENT.id,
+      "role_id"   = "REG_ADMIN"
+    }
+    "PLR_IAT/REG_ADMIN" = {
+      "client_id" = var.PLR_IAT.CLIENT.id,
+      "role_id"   = "REG_ADMIN"
+    }
+  }
+}
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "PLR_REV/REG_ADMIN" = var.PLR_REV.ROLES["REG_ADMIN"].id
+    "PLR_IAT/REG_ADMIN" = var.PLR_IAT.ROLES["REG_ADMIN"].id
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/plr-lra-regadmin/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-lra-regadmin/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/plr-lra-regadmin/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-lra-regadmin/variables.tf
@@ -1,0 +1,2 @@
+variable "PLR_REV" {}
+variable "PLR_IAT" {}

--- a/keycloak-test/realms/moh_applications/clients/plr-lra-regadmin/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-lra-regadmin/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Creating a service account client for LRA that will allow them to call PLR with REGADMIN permissions.

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.