### PR TITLE
create phlat client and management groups

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -192,6 +192,9 @@ module "ORGANIZATIONS-API" {
 module "PANORAMA" {
   source = "./clients/panorama"
 }
+module "PHLAT" {
+  source = "./clients/phlat"
+}
 module "PIDP-SERVICE" {
   source                  = "./clients/pidp-service"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE

--- a/keycloak-test/realms/moh_applications/clients/phlat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/phlat/main.tf
@@ -1,0 +1,55 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = "300"
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "PHLAT"
+  consent_required                    = false
+  description                         = "PLR Health Service Delivery Site Data Load Assistant Tool"
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "PHLAT"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = false
+  valid_redirect_uris = [
+    "https://d2llaidph43whp.cloudfront.net/app/*",
+    "https://localhost:*",
+    "http://localhost:*",
+  ]
+  web_origins = [
+  ]
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper-PHLAT" {
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "PHLAT"
+  name                        = "PHLAT Role Mapper"
+  claim_name                  = "roles"
+  multivalued                 = true
+  claim_value_type            = "String"
+  add_to_id_token             = true
+  add_to_access_token         = true
+  add_to_userinfo             = true
+}
+
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "REG_USER" : {
+      "name" : "REG_USER",
+    },
+    "REG_ADMIN" : {
+      "name" : "REG_ADMIN",
+    },
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/phlat/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/phlat/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/phlat/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/phlat/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/user-management-service/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management-service/main.tf
@@ -136,6 +136,9 @@ module "client-roles" {
     "view-client-mspdirect-service-uat" = {
       "name" = "view-client-mspdirect-service-uat"
     },
+    "view-client-phlat" = {
+      "name" = "view-client-phlat"
+    },
     "view-client-pidp-service" = {
       "name" = "view-client-pidp-service"
     },

--- a/keycloak-test/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management/main.tf
@@ -85,6 +85,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-client-miwt_stg"                  = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt_stg"].id,
     "USER-MANAGEMENT-SERVICE/view-client-mspdirect-service"         = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-mspdirect-service"].id,
     "USER-MANAGEMENT-SERVICE/view-client-mspdirect-service-uat"     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-mspdirect-service-uat"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-phlat"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-phlat"].id,
     "USER-MANAGEMENT-SERVICE/view-client-pidp-service"              = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pidp-service"].id,
     "USER-MANAGEMENT-SERVICE/view-client-plr_conf"                  = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_conf"].id,
     "USER-MANAGEMENT-SERVICE/view-client-plr_flvr"                  = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_flvr"].id,

--- a/keycloak-test/realms/moh_applications/groups.tf
+++ b/keycloak-test/realms/moh_applications/groups.tf
@@ -92,6 +92,11 @@ module "PAS-MANAGEMENT" {
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
 }
 
+module "PHLAT-MANAGEMENT" {
+  source                  = "./groups/phlat-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
 module "PIDP-MANAGEMENT" {
   source                  = "./groups/pidp-management"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE

--- a/keycloak-test/realms/moh_applications/groups/phlat-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/phlat-management/main.tf
@@ -1,0 +1,18 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "PHLAT Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-phlat"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-test/realms/moh_applications/groups/phlat-management/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/phlat-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/phlat-management/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/phlat-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/phlat-management/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/phlat-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/realm-roles/manage-users/main.tf
+++ b/keycloak-test/realms/moh_applications/realm-roles/manage-users/main.tf
@@ -35,6 +35,7 @@ resource "keycloak_role" "REALM_ROLE" {
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt_stg"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-mspdirect-service"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-mspdirect-service-uat"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-phlat"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pidp-service"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_conf"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr_flvr"].id,


### PR DESCRIPTION
### Changes being made

Create PHLAT basic client + management groups to allow UMC access.
### Context

New Client Onboarding

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [x] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
