### PR TITLE
add hssp redirect url

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -27,6 +27,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://moh-dms-m-sit-as-hspp.azurewebsites.net/*",
     "https://sithspp.hlth.gov.bc.ca/*",
     "https://uathspp.healthideas.gov.bc.ca/*",
+    "https://devhspp.hlth.gov.bc.ca/*",
   ]
   web_origins = [
   ]


### PR DESCRIPTION
### Changes being made

Add redirect URL for hspp on Keycloak Test env.


### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.