### PR TITLE
update health-ideas urls

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/health-ideas-apex/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/health-ideas-apex/main.tf
@@ -22,7 +22,9 @@ resource "keycloak_openid_client" "CLIENT" {
     "http://localhost:*",
     "https://localhost:*",
     "https://devsecure.healthideas.gov.bc.ca/*",
-    "https://uatsecure.healthideas.gov.bc.ca/*"
+    "https://uatsecure.healthideas.gov.bc.ca/*",
+    "https://devsecuret.healthideas.gov.bc.ca/*",
+    "https://uatsecuret.healthideas.gov.bc.ca/*",
   ]
   web_origins = [
 

--- a/keycloak-test/realms/moh_applications/clients/health-ideas/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/health-ideas/main.tf
@@ -22,7 +22,9 @@ resource "keycloak_openid_client" "CLIENT" {
     "http://localhost:*",
     "https://localhost:*",
     "https://devsecure.healthideas.gov.bc.ca/*",
-    "https://uatsecure.healthideas.gov.bc.ca/*"
+    "https://uatsecure.healthideas.gov.bc.ca/*",
+    "https://devsecuret.healthideas.gov.bc.ca/*",
+    "https://uatsecuret.healthideas.gov.bc.ca/*",
   ]
   web_origins = [
 


### PR DESCRIPTION
### Changes being made

Whitelisting URLS for HealthIdeas applications

### Context

Both applications reside under the same domain.

### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 