### PR TITLE
rename clients, fix phlat mapper, persist web origins

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/prp-web/main.tf
@@ -12,7 +12,7 @@ resource "keycloak_openid_client" "CLIENT" {
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
   implicit_flow_enabled               = false
-  name                                = "PRP Web"
+  name                                = "PRP"
   pkce_code_challenge_method          = "S256"
   realm_id                            = "moh_applications"
   service_accounts_enabled            = false

--- a/keycloak-test/realms/moh_applications/clients/phlat-web/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/phlat-web/main.tf
@@ -12,7 +12,7 @@ resource "keycloak_openid_client" "CLIENT" {
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
   implicit_flow_enabled               = false
-  name                                = "PHLAT-WEB"
+  name                                = "PHLAT"
   pkce_code_challenge_method          = "S256"
   realm_id                            = "moh_applications"
   service_accounts_enabled            = false
@@ -25,14 +25,14 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://phlat-dev.hlth.gov.bc.ca/*",
   ]
   web_origins = [
-    "+",
+    "*",
   ]
 }
 
 resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper-PHLAT" {
   realm_id                    = keycloak_openid_client.CLIENT.realm_id
   client_id                   = keycloak_openid_client.CLIENT.id
-  client_id_for_role_mappings = "PHLAT"
+  client_id_for_role_mappings = "PHLAT-WEB"
   name                        = "PHLAT Role Mapper"
   claim_name                  = "roles"
   multivalued                 = true

--- a/keycloak-test/realms/moh_applications/clients/phlat-web/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/phlat-web/main.tf
@@ -22,10 +22,12 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://d2llaidph43whp.cloudfront.net/app/*",
     "https://localhost:*",
     "http://localhost:*",
+    "http://localhost:5173/*",
+    "http://localhost:5174/*",
     "https://phlat-dev.hlth.gov.bc.ca/*",
   ]
   web_origins = [
-    "*",
+    "+",
   ]
 }
 

--- a/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
@@ -12,7 +12,7 @@ resource "keycloak_openid_client" "CLIENT" {
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
   implicit_flow_enabled               = false
-  name                                = "PRP Web"
+  name                                = "PRP"
   pkce_code_challenge_method          = "S256"
   realm_id                            = "moh_applications"
   service_accounts_enabled            = false


### PR DESCRIPTION
### Changes being made

CORS changes, client name changes

### Quality Check

- [ ] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.