### PR TITLE
Adding/removing valid redirect URIs to Metaspace Dev client configuration

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/metaspace/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/metaspace/main.tf
@@ -2,7 +2,7 @@ resource "keycloak_openid_client" "CLIENT" {
   access_token_lifespan               = ""
   access_type                         = "CONFIDENTIAL"
   backchannel_logout_session_required = true
-  base_url                            = "https://metadev.hlth.gov.bc.ca/"
+  base_url                            = "https://metadev.healthideas.gov.bc.ca/"
   client_authenticator_type           = "client-secret"
   client_id                           = "METASPACE"
   consent_required                    = false
@@ -20,7 +20,9 @@ resource "keycloak_openid_client" "CLIENT" {
   use_refresh_tokens                  = true
   valid_redirect_uris = [
     "https://metaspace.ddev.site/*",
-    "https://metadev.hlth.gov.bc.ca/*",
+    "https://metadev.healthideas.gov.bc.ca/*",
+    "https://metastg.healthideas.gov.bc.ca/*",
+    "https://meta.healthideas.gov.bc.ca/*",
     "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
     "https://qa-sts.healthbc.org/adfs/ls/*",
   ]


### PR DESCRIPTION
### Changes being made

Adding/removing valid redirect URIs to Metaspace Dev client configuration

### Context

Development on Metaspace has started back up in a push to have it completed by end of fiscal.

### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)