### PR TITLE
Updating ITSB Access Team group in Keycloak Dev/Prod

### DIFF
--- a/keycloak-dev/realms/moh_applications/groups/itsb-access-team/main.tf
+++ b/keycloak-dev/realms/moh_applications/groups/itsb-access-team/main.tf
@@ -14,6 +14,7 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hem"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pho-rsc"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-dbaac-portal"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-hibc-service-bc-portal"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-sfdc"].id,

--- a/keycloak-prod/realms/moh_applications/groups/itsb-access-team/main.tf
+++ b/keycloak-prod/realms/moh_applications/groups/itsb-access-team/main.tf
@@ -21,6 +21,7 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hscis"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-icy"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pho-rsc"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-dbaac-portal"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-hibc-service-bc-portal"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-sfdc"].id,


### PR DESCRIPTION
### Changes being made

Updating ITSB Access Team group in Keycloak Dev/Prod.

### Context

David Arnatt is requesting Keycloak group configuration updates and user roles removed from existing users for the PHO-RSC client in Production.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)