### PR TITLE
add mappers to edrd

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -44,7 +44,7 @@ module "EACL_STG" {
   source = "./clients/eacl_stg"
 }
 module "EDRD" {
-  source = "./clients/edrd"
+  source         = "./clients/edrd"
   LICENCE-STATUS = module.LICENCE-STATUS
 }
 module "EHPR" {

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -45,6 +45,7 @@ module "EACL_STG" {
 }
 module "EDRD" {
   source = "./clients/edrd"
+  LICENCE-STATUS = module.LICENCE-STATUS
 }
 module "EHPR" {
   source = "./clients/ehpr"

--- a/keycloak-test/realms/moh_applications/clients/edrd/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/edrd/main.tf
@@ -60,3 +60,27 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   name                        = "client roles"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id
 }
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "cpn" {
+  add_to_id_token     = true
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name          = "common_provider_number"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "cpn"
+  user_attribute      = "common_provider_number"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper-LICENCE-STATUS" {
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "LICENCE-STATUS"
+  name                        = "Client Role Mapper for LICENCE-STATUS"
+  claim_name                  = "roles"
+  multivalued                 = true
+  claim_value_type            = "String"
+  add_to_id_token             = true
+  add_to_access_token         = true
+  add_to_userinfo             = true
+}

--- a/keycloak-test/realms/moh_applications/clients/edrd/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/edrd/variables.tf
@@ -1,0 +1,1 @@
+variable "LICENCE-STATUS" {}


### PR DESCRIPTION
### Changes being made

Adding CPN and LICENCE-STATUS number to EDRD

### Context

Client needs those attributes to authenticate BCProvider accounts.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 