### PR TITLE
Add Metaspace Stg (Test) client for Hemant

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -171,6 +171,9 @@ module "LRA-TEST" {
 module "MAID" {
   source = "./clients/maid"
 }
+module "METASPACE" {
+  source = "./clients/metaspace"
+}
 module "MIWT" {
   source = "./clients/miwt"
 }

--- a/keycloak-test/realms/moh_applications/clients/metaspace/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/metaspace/main.tf
@@ -1,0 +1,100 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = "https://metastg.healthideas.gov.bc.ca/"
+  client_authenticator_type           = "client-secret"
+  client_id                           = "METASPACE"
+  consent_required                    = false
+  description                         = "Healthideas Metaspace is the metadata repository for the Ministry of Health's enterprise data warehouse (Healthideas)."
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "METASPACE"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+    "https://metastg.healthideas.gov.bc.ca/*",
+    "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
+    "https://qa-sts.healthbc.org/adfs/ls/*",
+  ]
+  web_origins = [
+  ]
+}
+
+resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
+  add_to_id_token  = true
+  claim_name       = "identity_provider"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "IDP"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "identity_provider"
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "idir_company" {
+  add_to_id_token = true
+  add_to_userinfo = false
+  claim_name      = "idir_company"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "idir_company"
+  user_attribute  = "idir_company"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "idir_displayName" {
+  add_to_id_token = true
+  add_to_userinfo = false
+  claim_name      = "idir_displayName"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "idir_displayName"
+  user_attribute  = "idir_displayName"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "idir_mailboxOrgCode" {
+  add_to_id_token = true
+  add_to_userinfo = false
+  claim_name      = "idir_mailboxOrgCode"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "idir_mailboxOrgCode"
+  user_attribute  = "idir_mailboxOrgCode"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "bceid_business_legalName" {
+  add_to_id_token = true
+  add_to_userinfo = false
+  claim_name      = "bceid_business_legalName"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "bceid_business_legalName"
+  user_attribute  = "bceid_business_legalName"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "email",
+    "profile",
+    "roles",
+    "web-origins"
+  ]
+}
+
+resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  optional_scopes = [
+    "address",
+    "microprofile-jwt",
+    "offline_access",
+    "phone"
+  ]
+}

--- a/keycloak-test/realms/moh_applications/clients/metaspace/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/metaspace/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/metaspace/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/metaspace/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Add Metaspace Stg (Test) client for Hemant.

### Context

Metaspace needs a Staging client setup in the Keycloak Test environment. They don't have an existing Test client and don't have plans for one, so we're not going through with a _STG client.

### Quality Check

- [ ] Client has Name and Description defined.
- [ ] Full Scope Allowed is disabled.
- [ ] Direct Access Grants Enabled is disabled.
- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [ ] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [ ] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [ ] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [ ] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
