### PR TITLE
bump action versions

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -20,10 +20,10 @@ jobs:
       TF_VAR_prod_client_secret: ${{ secrets.TF_VAR_PROD_CLIENT_SECRET }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ~1.3.7
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
@@ -33,12 +33,12 @@ jobs:
         run: terraform fmt -check -recursive -diff
 
       - name: Terraform Format Error Details
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ failure() }}
         with:
           script: |
             const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
-           
+
             <details><summary>Terraform formatting errors</summary>
 
             \`\`\`\n
@@ -86,7 +86,7 @@ jobs:
           echo "${plan}" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         if: github.event_name == 'pull_request'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Changes being made

Updating GitHub Actions: actions/checkout@v3, hashicorp/setup-terraform@v2, actions/github-script@v6

### Context

[Terraform](https://github.com/bcgov/moh-keycloak-client-configurations/actions/runs/8367023478/job/22908530378)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, hashicorp/setup-terraform@v2, actions/github-script@v6. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
