### PR TITLE
add clientId mapper

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/plr-shoppers/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-shoppers/main.tf
@@ -23,6 +23,15 @@ resource "keycloak_openid_client" "CLIENT" {
   web_origins = [
   ]
 }
+resource "keycloak_openid_user_session_note_protocol_mapper" "Client-ID" {
+  add_to_id_token  = true
+  claim_name       = "clientId"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "Client ID"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "clientId"
+}
 resource "keycloak_openid_hardcoded_claim_protocol_mapper" "orgId" {
   add_to_access_token = true
   add_to_id_token     = true


### PR DESCRIPTION
### Changes being made

Add clientId mapper to PLR-SHOPPERS client.

### Context

PLR-SHOPPERS cannot call PLR service, because clientId mapper is missing in the access token.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.
