### PR TITLE
create cg-salesforce group in test, update itsb permissions

### DIFF
--- a/keycloak-prod/realms/moh_applications/groups/itsb-access-team/main.tf
+++ b/keycloak-prod/realms/moh_applications/groups/itsb-access-team/main.tf
@@ -20,6 +20,7 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hamis"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hscis"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-icy"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-maid"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pho-rsc"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-dbaac-portal"].id,

--- a/keycloak-test/realms/moh_applications/groups.tf
+++ b/keycloak-test/realms/moh_applications/groups.tf
@@ -15,6 +15,11 @@ module "CGI-MIDTIER" {
   realm-management        = module.realm-management
 }
 
+module "CGI-SALESFORCE" {
+  source                  = "./groups/cgi-salesforce"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
 module "CGI-QA" {
   source                  = "./groups/cgi-qa"
   CGI-APPLICATION-SUPPORT = module.CGI-APPLICATION-SUPPORT

--- a/keycloak-test/realms/moh_applications/groups/cgi-salesforce/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-salesforce/main.tf
@@ -1,6 +1,6 @@
 resource "keycloak_group" "GROUP" {
   realm_id = "moh_applications"
-  name     = "ITSB Access Team"
+  name     = "CGI Salesforce"
 }
 
 resource "keycloak_group_roles" "GROUP_ROLES" {
@@ -9,29 +9,16 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
 
   role_ids = [
     var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["manage-org"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-alr"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl_stg"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-fmdb"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-gis"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hamis"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hscis"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-edrd"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-icy"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-maid"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt_stg"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-dbaac-portal"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-hibc-service-bc-portal"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-sfdc"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sfds"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-swt"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-swt_stg"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-tap"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-tpl"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,

--- a/keycloak-test/realms/moh_applications/groups/cgi-salesforce/output.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-salesforce/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-test/realms/moh_applications/groups/cgi-salesforce/variables.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-salesforce/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/groups/cgi-salesforce/versions.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-salesforce/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Creating CGI-Salesforce access management group on Test environment. Updating ITSB permissions.


### Quality Check

- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.