### PR TITLE
Add phsa_windowsaccountname mapper to DEV clients

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/bcer-cp/main.tf
@@ -45,3 +45,12 @@ module "client-roles" {
     },
   }
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "preferred_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-dev/realms/moh_applications/clients/connect/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/connect/main.tf
@@ -69,3 +69,12 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "preferred_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-dev/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/forms/main.tf
@@ -69,3 +69,12 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "preferred_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-dev/realms/moh_applications/clients/hcimweb/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/hcimweb/main.tf
@@ -75,3 +75,12 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+  add_to_id_token = false
+  add_to_userinfo = false
+  claim_name      = "preferred_username"
+  client_id       = module.payara-client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = module.payara-client.CLIENT.realm_id
+}

--- a/keycloak-dev/realms/moh_applications/clients/moh-servicenow/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/moh-servicenow/main.tf
@@ -42,3 +42,12 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider"
   realm_id         = keycloak_openid_client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "preferred_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-dev/realms/moh_applications/clients/pidp-service-account/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pidp-service-account/main.tf
@@ -71,3 +71,12 @@ module "service-account-roles" {
     }
   }
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+  add_to_id_token = true
+  add_to_userinfo = false
+  claim_name      = "preferred_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-dev/realms/moh_applications/clients/pidp-webapp/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pidp-webapp/main.tf
@@ -355,3 +355,12 @@ module "scope-mappings" {
     "account/view-profile"           = var.account.ROLES["view-profile"].id,
   }
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "preferred_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-dev/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/prp-web/main.tf
@@ -55,3 +55,12 @@ module "scope-mappings" {
     "PRP-SERVICE/MSPQI"      = var.PRP-SERVICE.ROLES["MSPQI"].id,
   }
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "preferred_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}


### PR DESCRIPTION
### Changes being made

Add phsa_windowsaccountname mapper to DEV clients that use PHSA login. Clients were identified by querying logins on the PROD and TEST events database. Prractically no one is using PHSA login on DEV, so no events were found other than `account`, but this is still being applied to DEV to check the changes.

### Context

This change will allow applications to continue using the "legacy" PHSA username after the upcoming planned change to username format.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
