### PR TITLE
create hcim-fha-dfd test client

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -461,6 +461,9 @@ module "HCIM_BCMI" {
 module "HCIM_FHA" {
   source = "./clients/hcim_fha"
 }
+module "HCIM_FHA_DFD" {
+  source = "./clients/hcim_fha_dfd"
+}
 module "HCIM_HIBC" {
   source = "./clients/hcim_hibc"
 }

--- a/keycloak-test/realms/moh_applications/clients/hcim_fha_dfd/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcim_fha_dfd/main.tf
@@ -1,0 +1,46 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "HCIM_FHA_DFD"
+  consent_required                    = false
+  description                         = "Healthcare Client Identity Management (Fraser Health Authority - Digital Front Door)."
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = ""
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = true
+  standard_flow_enabled               = false
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+module "service-account-roles" {
+  source                  = "../../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {}
+}
+resource "keycloak_openid_hardcoded_claim_protocol_mapper" "hcim_org" {
+  add_to_access_token = true
+  add_to_id_token     = true
+  add_to_userinfo     = true
+  claim_name          = "hcim_org"
+  claim_value         = "organization/FHA_DFD"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "hcim_org"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-test/realms/moh_applications/clients/hcim_fha_dfd/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcim_fha_dfd/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/hcim_fha_dfd/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcim_fha_dfd/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Create new service account from HCIM on test env: HCIM_FHA_DFD (Fraser Health Authority - Digital Front Door).
The template for this client is HCIM_LRA.

Service account - no client name

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.