### PR TITLE
create hcimweb_hs1 client on prod, update ums and realm roles

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients.tf
+++ b/keycloak-prod/realms/moh_applications/clients.tf
@@ -59,6 +59,9 @@ module "HCAP-SERVICE" {
 module "HCIMWEB" {
   source = "./clients/hcimweb"
 }
+module "HCIMWEB_HS1" {
+  source = "./clients/hcimweb_hs1"
+}
 module "HCIM_LRA" {
   source = "./clients/hcim_lra"
 }

--- a/keycloak-prod/realms/moh_applications/clients/hcimweb_hs1/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hcimweb_hs1/main.tf
@@ -48,7 +48,7 @@ module "payara-client" {
   use_refresh_tokens       = false
   valid_redirect_uris = [
     "https://hcimweb-cl-stg.hlth.gov.bc.ca/*",
-    "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
+    "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi*",
     "https://sts.healthbc.org/adfs/ls/*",
   ]
 }

--- a/keycloak-prod/realms/moh_applications/clients/hcimweb_hs1/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hcimweb_hs1/main.tf
@@ -1,0 +1,72 @@
+module "payara-client" {
+  source                             = "../../../../../modules/payara-client"
+  base_url                           = "https://hcimweb-cl-stg.hlth.gov.bc.ca/HCIMWeb"
+  claim_name                         = "hcimweb_role"
+  client_id                          = "HCIMWEB_HS1"
+  client_name                        = "HCIMWEB HS1 - Staging"
+  client_role_mapper_add_to_id_token = false
+  client_role_mapper_add_to_userinfo = false
+  description                        = "The Healthcare Client Identity Management Web Application provides a web interface to the HCIM system services, allowing point-of-service users to find, add or update health clients, view documented identity and confirm eligibility."
+  login_theme                        = "moh-app-realm-bcsc-idp"
+  mapper_name                        = "HCIMWEB Role"
+  roles = {
+    "HIBC_REG_NEWBORN" = {
+      "name" = "HIBC_REG_NEWBORN"
+    },
+    "MAINTR_FULL" = {
+      "name" = "MAINTR_FULL"
+    },
+    "MAINTR_READ_ONLY" = {
+      "name" = "MAINTR_READ_ONLY"
+    },
+    "MAINTR_UPDT" = {
+      "name" = "MAINTR_UPDT"
+    },
+    "READ_ONLY_ALL_SRC" = {
+      "name" = "READ_ONLY_ALL_SRC"
+    },
+    "REGR_FULL" = {
+      "name" = "REGR_FULL"
+    },
+    "REGR_LTD" = {
+      "name" = "REGR_LTD"
+    },
+    "REGR_UPDT" = {
+      "name" = "REGR_UPDT"
+    },
+    "REGR_UPDT_ADDR_ONLY" = {
+      "name" = "REGR_UPDT_ADDR_ONLY"
+    },
+    "REG_ADMIN_HCIM" = {
+      "name" = "REG_ADMIN_HCIM"
+    },
+    "REG_INTEGRITY_CLERK" = {
+      "name" = "REG_INTEGRITY_CLERK"
+    },
+  }
+  service_accounts_enabled = false
+  use_refresh_tokens       = false
+  valid_redirect_uris = [
+    "https://hcimweb-cl-stg.hlth.gov.bc.ca/*",
+    "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
+    "https://sts.healthbc.org/adfs/ls/*",
+  ]
+}
+resource "keycloak_openid_user_attribute_protocol_mapper" "org_details" {
+  add_to_id_token = false
+  add_to_userinfo = false
+  claim_name      = "org_details"
+  client_id       = module.payara-client.CLIENT.id
+  name            = "org_details"
+  user_attribute  = "org_details"
+  realm_id        = module.payara-client.CLIENT.realm_id
+}
+resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
+  add_to_id_token  = false
+  claim_name       = "identity_provider"
+  claim_value_type = "String"
+  client_id        = module.payara-client.CLIENT.id
+  name             = "IDP"
+  realm_id         = module.payara-client.CLIENT.realm_id
+  session_note     = "identity_provider"
+}

--- a/keycloak-prod/realms/moh_applications/clients/hcimweb_hs1/outputs.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hcimweb_hs1/outputs.tf
@@ -1,0 +1,6 @@
+output "CLIENT" {
+  value = module.payara-client.CLIENT
+}
+output "ROLES" {
+  value = module.payara-client.ROLES
+}

--- a/keycloak-prod/realms/moh_applications/clients/hcimweb_hs1/versions.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hcimweb_hs1/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/user-management-service/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/user-management-service/main.tf
@@ -76,6 +76,9 @@ module "client-roles" {
     "view-client-hcimweb" = {
       "name" = "view-client-hcimweb"
     },
+    "view-client-hcimweb_hs1" = {
+      "name" = "view-client-hcimweb_hs1"
+    },
     "view-client-health-ideas" = {
       "name" = "view-client-health-ideas"
     }

--- a/keycloak-prod/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/user-management/main.tf
@@ -65,6 +65,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-client-gis"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-gis"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hamis"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hamis"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hcimweb"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-hcimweb_hs1"               = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_hs1"].id,
     "USER-MANAGEMENT-SERVICE/view-client-health-ideas"              = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-health-ideas"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hem"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hem"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hscis"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hscis"].id,

--- a/keycloak-prod/realms/moh_applications/realm-roles/manage-users/main.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/manage-users/main.tf
@@ -15,6 +15,7 @@ resource "keycloak_role" "REALM_ROLE" {
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hamis"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcap-fe"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_hs1"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hem"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hscis"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hsiar"].id,
@@ -46,7 +47,7 @@ resource "keycloak_role" "REALM_ROLE" {
     var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
     var.USER-MANAGEMENT.ROLES["user-management-admin"].id,
   ]
-  description = "Provides the roles required to manage users using the USER-MANAGEMENT application including roles for all applications. In PROD this role is not provided to specific teams."
+  description = "Provides the roles required to manage users using the USER-MANAGEMENT application including roles for all applications. In PROD this role is provided to CGI Developer and Mid-tier"
   name        = "Manage Users"
   realm_id    = "moh_applications"
 }


### PR DESCRIPTION
### Changes being made

Copying HCIMWEB_HS1 client to Production environment. Add `view-client-hcimweb_hs1` role to UMC and scope mapping to UMC to allow managing roles for this client through User Management Console. Add `view-client-hcimweb_hs1` to ManageUsers realm role.

### Context

HCIM team wants to connect their staging environment to Keycloak Production. HCIMWEB_HS1 client on test is kept intact in case rollback is needed.
Terraform apply will likely need to be re-run as composite role is being updated.

### Quality Check

- [ ] Client has Name and Description defined.
- [ ] Full Scope Allowed is disabled.
- [ ] Direct Access Grants Enabled is disabled.
- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [ ] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [ ] Client Scopes are not assigned to client, or explanation for doing so is provided.
- [ ] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.
- [ ] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. 
