### PR TITLE
Recreate HSIAR roles with new names

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/hsiar/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hsiar/main.tf
@@ -45,14 +45,14 @@ module "client-roles" {
     "HI_Administrator" = {
       "name" = "HI_Administrator"
     },
-    "HI_ReportProgram_All" = {
-      "name" = "HI_ReportProgram_All"
+    "HI_SUPPORT_ROLE_PROGRAM" = {
+      "name" = "HI_SUPPORT_ROLE_PROGRAM"
     },
-    "HI_ReportSection_All" = {
-      "name" = "HI_ReportSection_All"
+    "HI_SUPPORT_ROLE_SECTION" = {
+      "name" = "HI_SUPPORT_ROLE_SECTION"
     },
-    "HI_Consumer" = {
-      "name" = "HI_Consumer"
+    "HI_SUPPORT_ROLE" = {
+      "name" = "HI_SUPPORT_ROLE"
     },
     "HI_Operation" = {
       "name" = "HI_Operation"

--- a/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
@@ -49,14 +49,14 @@ module "client-roles" {
     "HI_Administrator" = {
       "name" = "HI_Administrator"
     },
-    "HI_ReportProgram_All" = {
-      "name" = "HI_ReportProgram_All"
+    "HI_SUPPORT_ROLE_PROGRAM" = {
+      "name" = "HI_SUPPORT_ROLE_PROGRAM"
     },
-    "HI_ReportSection_All" = {
-      "name" = "HI_ReportSection_All"
+    "HI_SUPPORT_ROLE_SECTION" = {
+      "name" = "HI_SUPPORT_ROLE_SECTION"
     },
-    "HI_Consumer" = {
-      "name" = "HI_Consumer"
+    "HI_SUPPORT_ROLE" = {
+      "name" = "HI_SUPPORT_ROLE"
     },
     "HI_Operation" = {
       "name" = "HI_Operation"


### PR DESCRIPTION
### Changes being made

Recreate HSIAR roles using new names.

### Context

> Hi Keycloak team,
> 
> Can you help to rename these roles below in the Test environment?
> Existing role name	New role name
> HI_Consumer	HI_SUPPORT_ROLE
> HI_ReportSection_All	HI_SUPPORT_ROLE_SECTION
> HI_ReportProgram_All	HI_SUPPORT_ROLE_PROGRAM
> 
> I believe these roles does not exist in Prod yet. But if they are, please help to rename the Prod version too.
> Sri

Sri has acknowledged that users with these roles currently assigned will lose the roles. They will need to be manually reassigned by Sri.

No one is currently assigned the roles in PROD. 14 users are assigned various HSIAR roles in TEST.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
