### PR TITLE
Update HEALTH-IDEAS redirect URLs in TEST and PROD

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/health-ideas-apex/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/health-ideas-apex/main.tf
@@ -21,6 +21,8 @@ resource "keycloak_openid_client" "CLIENT" {
   valid_redirect_uris = [
     "https://secure.healthideas.gov.bc.ca/*",
     "https://securet.healthideas.gov.bc.ca/*",
+    "https://external.healthideas.gov.bc.ca/*",
+    "https://externalt.healthideas.gov.bc.ca/*"
   ]
   web_origins = [
 

--- a/keycloak-prod/realms/moh_applications/clients/health-ideas/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/health-ideas/main.tf
@@ -21,6 +21,8 @@ resource "keycloak_openid_client" "CLIENT" {
   valid_redirect_uris = [
     "https://secure.healthideas.gov.bc.ca/*",
     "https://securet.healthideas.gov.bc.ca/*",
+    "https://external.healthideas.gov.bc.ca/*",
+    "https://externalt.healthideas.gov.bc.ca/*"
   ]
   web_origins = [
 

--- a/keycloak-test/realms/moh_applications/clients/health-ideas-apex/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/health-ideas-apex/main.tf
@@ -25,6 +25,8 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://uatsecure.healthideas.gov.bc.ca/*",
     "https://devsecuret.healthideas.gov.bc.ca/*",
     "https://uatsecuret.healthideas.gov.bc.ca/*",
+    "https://uatexternal.healthideas.gov.bc.ca/*",
+    "https://uatexternalt.healthideas.gov.bc.ca/*"
   ]
   web_origins = [
 

--- a/keycloak-test/realms/moh_applications/clients/health-ideas/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/health-ideas/main.tf
@@ -25,6 +25,8 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://uatsecure.healthideas.gov.bc.ca/*",
     "https://devsecuret.healthideas.gov.bc.ca/*",
     "https://uatsecuret.healthideas.gov.bc.ca/*",
+    "https://uatexternal.healthideas.gov.bc.ca/*",
+    "https://uatexternalt.healthideas.gov.bc.ca/*"
   ]
   web_origins = [
 


### PR DESCRIPTION
### Changes being made

Update HEALTH-IDEAS redirect URLs in TEST and PROD

### Context

> For both our applications (HEALTH-IDEAS-APEX and HEALTH-IDEAS ) we currently have the following  URLs:
>  
> TEST keycloak:
> https://devsecure.healthideas.gov.bc.ca/<anyurl>
> https://uatsecure.healthideas.gov.bc.ca/<anyurl>
> https://devsecuret.healthideas.gov.bc.ca/<anyurl>
> https://uatsecuret.healthideas.gov.bc.ca/<anyurl>
> https://localhost:<anyport>/<anyurl>
> 
> PROD:
> https://secure.healthideas.gov.bc.ca/<anyurl>
> https://securet.healthideas.gov.bc.ca/<anyurl>
> 
> 
> Can you please add the following URLs to the configuration?
> 
> TEST keycloak:
> uatexternal.healthideas.gov.bc.ca/<anyurl>
> uatexternalt.healthideas.gov.bc.ca/<anyurl>
> 
> PROD:
> external.healthideas.gov.bc.ca/<anyurl>
> externalt.healthideas.gov.bc.ca/<anyurl>
> 
> Thank you,
> 
> Calin 

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
