### PR TITLE
Create PHO-RSC-GROUPS bearer-only client on DEV

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients.tf
+++ b/keycloak-dev/realms/moh_applications/clients.tf
@@ -86,7 +86,11 @@ module "ORGANIZATIONS-API" {
   source = "./clients/organizations-api"
 }
 module "PHO-RSC" {
-  source = "./clients/pho-rsc"
+  source         = "./clients/pho-rsc"
+  PHO-RSC-GROUPS = module.PHO-RSC-GROUPS
+}
+module "PHO-RSC-GROUPS" {
+  source = "./clients/pho-rsc-groups"
 }
 module "PIDP-SERVICE" {
   source                  = "./clients/pidp-service"

--- a/keycloak-dev/realms/moh_applications/clients/pho-rsc-groups/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pho-rsc-groups/main.tf
@@ -1,0 +1,51 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "BEARER-ONLY"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "PHO-RSC-GROUPS"
+  consent_required                    = false
+  description                         = ""
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = ""
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = false
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "opho" = {
+      "name"        = "opho"
+      "description" = ""
+    },
+    "hsiar_ppd" = {
+      "name"        = "hsiar_ppd"
+      "description" = ""
+    },
+    "hsiar_dart" = {
+      "name"        = "hsiar_dart"
+      "description" = ""
+    },
+    "hsiar_wfa" = {
+      "name"        = "hsiar_wfa"
+      "description" = ""
+    },
+    "hsiar_phar" = {
+      "name"        = "hsiar_phar"
+      "description" = ""
+    }
+  }
+}

--- a/keycloak-dev/realms/moh_applications/clients/pho-rsc-groups/outputs.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pho-rsc-groups/outputs.tf
@@ -1,0 +1,6 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}
+output "ROLES" {
+  value = module.client-roles.ROLES
+}

--- a/keycloak-dev/realms/moh_applications/clients/pho-rsc-groups/versions.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pho-rsc-groups/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-dev/realms/moh_applications/clients/pho-rsc/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pho-rsc/main.tf
@@ -80,6 +80,16 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "PHO-RSC-Role" {
   add_to_userinfo             = false
   client_id_for_role_mappings = "PHO-RSC"
 }
+resource "keycloak_openid_user_client_role_protocol_mapper" "PHO-RSC-Role-Groups" {
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+  client_id                   = keycloak_openid_client.CLIENT.id
+  name                        = "PHO-RSC Role Groups"
+  claim_name                  = "pho-rsc_role_groups"
+  claim_value_type            = "String"
+  add_to_access_token         = false
+  add_to_userinfo             = false
+  client_id_for_role_mappings = "PHO-RSC-GROUPS"
+}
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-dev/realms/moh_applications/clients/pho-rsc/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pho-rsc/main.tf
@@ -88,3 +88,15 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "profile"
   ]
 }
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "PHO-RSC-GROUPS/opho" = var.PHO-RSC-GROUPS.ROLES["opho"].id,
+    "PHO-RSC-GROUPS/hsiar_ppd" = var.PHO-RSC-GROUPS.ROLES["hsiar_ppd"].id,
+    "PHO-RSC-GROUPS/hsiar_dart" = var.PHO-RSC-GROUPS.ROLES["hsiar_dart"].id,
+    "PHO-RSC-GROUPS/hsiar_wfa" = var.PHO-RSC-GROUPS.ROLES["hsiar_wfa"].id,
+    "PHO-RSC-GROUPS/hsiar_phar" = var.PHO-RSC-GROUPS.ROLES["hsiar_phar"].id,
+  }
+}

--- a/keycloak-dev/realms/moh_applications/clients/pho-rsc/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pho-rsc/main.tf
@@ -93,10 +93,10 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "PHO-RSC-GROUPS/opho" = var.PHO-RSC-GROUPS.ROLES["opho"].id,
-    "PHO-RSC-GROUPS/hsiar_ppd" = var.PHO-RSC-GROUPS.ROLES["hsiar_ppd"].id,
+    "PHO-RSC-GROUPS/opho"       = var.PHO-RSC-GROUPS.ROLES["opho"].id,
+    "PHO-RSC-GROUPS/hsiar_ppd"  = var.PHO-RSC-GROUPS.ROLES["hsiar_ppd"].id,
     "PHO-RSC-GROUPS/hsiar_dart" = var.PHO-RSC-GROUPS.ROLES["hsiar_dart"].id,
-    "PHO-RSC-GROUPS/hsiar_wfa" = var.PHO-RSC-GROUPS.ROLES["hsiar_wfa"].id,
+    "PHO-RSC-GROUPS/hsiar_wfa"  = var.PHO-RSC-GROUPS.ROLES["hsiar_wfa"].id,
     "PHO-RSC-GROUPS/hsiar_phar" = var.PHO-RSC-GROUPS.ROLES["hsiar_phar"].id,
   }
 }

--- a/keycloak-dev/realms/moh_applications/clients/pho-rsc/variables.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pho-rsc/variables.tf
@@ -1,0 +1,1 @@
+variable "PHO-RSC-GROUPS" {}

--- a/keycloak-dev/realms/moh_applications/clients/user-management-service/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/user-management-service/main.tf
@@ -94,6 +94,9 @@ module "client-roles" {
     "view-client-pho-rsc" = {
       "name" = "view-client-pho-rsc"
     },
+    "view-client-pho-rsc-groups" = {
+      "name" = "view-client-pho-rsc-groups"
+    },
     "view-client-ums-integration-tests" = {
       "name" = "view-client-ums-integration-tests"
     },

--- a/keycloak-dev/realms/moh_applications/groups/pho-rsc-management/main.tf
+++ b/keycloak-dev/realms/moh_applications/groups/pho-rsc-management/main.tf
@@ -1,0 +1,21 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "PHO-RSC Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pho-rsc"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pho-rsc-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-events"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-dev/realms/moh_applications/groups/pho-rsc-management/output.tf
+++ b/keycloak-dev/realms/moh_applications/groups/pho-rsc-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-dev/realms/moh_applications/groups/pho-rsc-management/variables.tf
+++ b/keycloak-dev/realms/moh_applications/groups/pho-rsc-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-dev/realms/moh_applications/groups/pho-rsc-management/versions.tf
+++ b/keycloak-dev/realms/moh_applications/groups/pho-rsc-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Create PHO-RSC-GROUPS bearer-only client on DEV and set-up UMC/UMS management.

Included changes:
* Set-up new bearer-only client to hold roles specified by development team.
* Add scope mappings to existing client.
* Set-up UMC/UMS to enable management of new client.
* Copy PROD PHO-RSC group to development for testing. Add new client.

### Context

The PHO-RSC development team has requested a separate client to manage a seperate set of roles, that they call "groups."

### Quality Check

- [ ] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [x] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [x] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
