### PR TITLE
PHLAT-WEB (TEST): Increase token lifespan to two hours to allow ZAP scan to complete

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/phlat-web/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/phlat-web/main.tf
@@ -1,5 +1,6 @@
 resource "keycloak_openid_client" "CLIENT" {
-  access_token_lifespan               = ""
+  # Set token lifespan to TWO HOURS in TEST for ZAP scan.
+  access_token_lifespan               = "7200"
   access_type                         = "PUBLIC"
   backchannel_logout_session_required = true
   base_url                            = ""


### PR DESCRIPTION
### Changes being made

PHLAT-WEB (TEST): Increase token lifespan to two hours to allow ZAP scan to complete

### Context

PHLAT-WEB developer requests changes.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
