### PR TITLE
PLR-CPSBC (TEST): Specify client ID format in the token.

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/plr-cpsbc/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr-cpsbc/main.tf
@@ -22,6 +22,15 @@ resource "keycloak_openid_client" "CLIENT" {
   web_origins = [
   ]
 }
+resource "keycloak_openid_user_session_note_protocol_mapper" "PLR-Client-ID" {
+  add_to_id_token  = true
+  claim_name       = "clientId"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "PLR Client ID"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "clientId"
+}
 resource "keycloak_openid_hardcoded_claim_protocol_mapper" "orgId" {
   add_to_access_token = true
   add_to_id_token     = true


### PR DESCRIPTION
### Changes being made

PLR-CPSBC (TEST): Specify client ID format in the token.

### Context

PLR-ESB looks for the client ID in the token in a specific format. The Keycloak default used to match the intended format, but Keycloak 20 changed it to client_id to be more specification compliant.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
