### PR TITLE
Remove mhsu_ehs event configuration because realm is disabled

### DIFF
--- a/keycloak-dev/events.tf
+++ b/keycloak-dev/events.tf
@@ -301,23 +301,6 @@ resource "keycloak_realm_events" "realm_events_idir_aad" {
   ]
 }
 
-resource "keycloak_realm_events" "realm_events_mhsu_ehs" {
-  realm_id = "mhsu_ehs"
-
-  events_enabled    = false
-  events_expiration = local.seconds_in_a_year
-
-  admin_events_enabled         = true
-  admin_events_details_enabled = true
-
-  # When omitted or left empty, keycloak will enable all event types
-  enabled_event_types = local.event_types
-
-  events_listeners = [
-    "jboss-logging", # keycloak enables the 'jboss-logging' event listener by default.
-  ]
-}
-
 resource "keycloak_realm_events" "realm_events_moh_idp" {
   realm_id = "moh_idp"
 


### PR DESCRIPTION
### Changes being made

Remove mhsu_ehs event configuration because realm is disabled

### Context

Realm is being decomissioned.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
