### PR TITLE
Add PHSA username mapper to all DEV clients that use PHSA login

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/bcer-cp/main.tf
@@ -45,3 +45,12 @@ module "client-roles" {
     },
   }
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "preferred_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-dev/realms/moh_applications/clients/connect/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/connect/main.tf
@@ -69,3 +69,12 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "preferred_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-dev/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/forms/main.tf
@@ -69,3 +69,12 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "preferred_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-dev/realms/moh_applications/clients/hcimweb/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/hcimweb/main.tf
@@ -75,3 +75,12 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+  add_to_id_token = false
+  add_to_userinfo = false
+  claim_name      = "preferred_username"
+  client_id       = module.payara-client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = module.payara-client.CLIENT.realm_id
+}

--- a/keycloak-dev/realms/moh_applications/clients/moh-servicenow/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/moh-servicenow/main.tf
@@ -42,3 +42,12 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider"
   realm_id         = keycloak_openid_client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "preferred_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-dev/realms/moh_applications/clients/pidp-webapp/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pidp-webapp/main.tf
@@ -355,3 +355,12 @@ module "scope-mappings" {
     "account/view-profile"           = var.account.ROLES["view-profile"].id,
   }
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "preferred_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-dev/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/prp-web/main.tf
@@ -55,3 +55,12 @@ module "scope-mappings" {
     "PRP-SERVICE/MSPQI"      = var.PRP-SERVICE.ROLES["MSPQI"].id,
   }
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "preferred_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}


### PR DESCRIPTION
### Changes being made

Add PHSA username mapper to all DEV clients that use PHSA login.

### Context

Adds a client attribute mapper mapper that checks for the presence of a user attribute named phsa_windowsaccoutname, and, if it's present, it replaces preferred_username in the token.

A separate script will create the phsa_windowsaccoutname attribute on PHSA users.

According to my manual tests, this mapper will have no impact until the phsa_windowsaccountname exists.

Later, the IDP configuration will be updated to overwrite the existing Keycloak registration username with the UPN from PHSA.

The whole point of this is to allow applications that have already started using the "windowsaccountname" format to continue receiving it for existing users, while for new users they will receive the new UPN format.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
