### PR TITLE
Add PHSA username mappers to all TEST clients that use PHSA login: Panorama

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
@@ -48,12 +48,12 @@ module "client-roles" {
   }
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = true
   add_to_userinfo = true
   claim_name      = "preferred_username"
   client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/connect/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/connect/main.tf
@@ -71,12 +71,12 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
   ]
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = true
   add_to_userinfo = true
   claim_name      = "preferred_username"
   client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/dht-dev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/dht-dev/main.tf
@@ -52,12 +52,12 @@ module "scope-mappings" {
   }
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = true
   add_to_userinfo = true
   claim_name      = "preferred_username"
   client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/forms/main.tf
@@ -71,12 +71,12 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
   ]
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = true
   add_to_userinfo = true
   claim_name      = "preferred_username"
   client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/gis/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/gis/main.tf
@@ -26,12 +26,12 @@ module "payara-client" {
   ]
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = false
   add_to_userinfo = false
   claim_name      = "preferred_username"
   client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = module.payara-client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/hamis/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hamis/main.tf
@@ -100,12 +100,12 @@ module "service-account-roles" {
   }
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = false
   add_to_userinfo = false
   claim_name      = "preferred_username"
   client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = module.payara-client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hiat1/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hiat1/main.tf
@@ -71,12 +71,12 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   session_note     = "identity_provider"
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = false
   add_to_userinfo = false
   claim_name      = "preferred_username"
   client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = module.payara-client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hiat2/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hiat2/main.tf
@@ -71,12 +71,12 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   session_note     = "identity_provider"
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = false
   add_to_userinfo = false
   claim_name      = "preferred_username"
   client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = module.payara-client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hiat3/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hiat3/main.tf
@@ -71,12 +71,12 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   session_note     = "identity_provider"
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = false
   add_to_userinfo = false
   claim_name      = "preferred_username"
   client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = module.payara-client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hs1/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hs1/main.tf
@@ -71,12 +71,12 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   session_note     = "identity_provider"
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = false
   add_to_userinfo = false
   claim_name      = "preferred_username"
   client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = module.payara-client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_huat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_huat/main.tf
@@ -72,12 +72,12 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   session_note     = "identity_provider"
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = false
   add_to_userinfo = false
   claim_name      = "preferred_username"
   client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = module.payara-client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/hscis/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hscis/main.tf
@@ -87,12 +87,12 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   session_note     = "identity_provider"
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = false
   add_to_userinfo = false
   claim_name      = "preferred_username"
   client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = module.payara-client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
@@ -99,12 +99,12 @@ module "client-roles" {
     },
   }
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = true
   add_to_userinfo = true
   claim_name      = "preferred_username"
   client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -156,12 +156,12 @@ module "client-roles" {
     },
   }
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = true
   add_to_userinfo = true
   claim_name      = "preferred_username"
   client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/lra-dev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-dev/main.tf
@@ -53,12 +53,12 @@ module "scope-mappings" {
   }
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = true
   add_to_userinfo = true
   claim_name      = "preferred_username"
   client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/miwt_stg/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/miwt_stg/main.tf
@@ -52,12 +52,12 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   session_note     = "identity_provider"
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = false
   add_to_userinfo = false
   claim_name      = "preferred_username"
   client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = module.payara-client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/moh-servicenow/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/moh-servicenow/main.tf
@@ -45,12 +45,12 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider"
   session_note     = "identity_provider"
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = true
   add_to_userinfo = true
   claim_name      = "preferred_username"
   client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/panorama/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/panorama/main.tf
@@ -32,7 +32,6 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider"
   realm_id         = keycloak_openid_client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
-
 resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
   add_to_id_token = true
   add_to_userinfo = true
@@ -42,12 +41,13 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutnam
   user_attribute  = "phsa_windowsaccoutname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = true
   add_to_userinfo = true
   claim_name      = "preferred_username"
   client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/panorama/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/panorama/main.tf
@@ -43,11 +43,11 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutnam
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
 resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
-add_to_id_token = true
-add_to_userinfo = true
-claim_name      = "preferred_username"
-client_id       = keycloak_openid_client.CLIENT.id
-name            = "phsa_windowsaccoutname"
-user_attribute  = "phsa_windowsaccoutname"
-realm_id        = keycloak_openid_client.CLIENT.realm_id
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "preferred_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "phsa_windowsaccoutname"
+  user_attribute  = "phsa_windowsaccoutname"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/panorama/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/panorama/main.tf
@@ -42,3 +42,12 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutnam
   user_attribute  = "phsa_windowsaccoutname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+add_to_id_token = true
+add_to_userinfo = true
+claim_name      = "preferred_username"
+client_id       = keycloak_openid_client.CLIENT.id
+name            = "phsa_windowsaccoutname"
+user_attribute  = "phsa_windowsaccoutname"
+realm_id        = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-test/realms/moh_applications/clients/pidp-webapp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/pidp-webapp/main.tf
@@ -73,12 +73,12 @@ module "scope-mappings" {
   }
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = true
   add_to_userinfo = true
   claim_name      = "preferred_username"
   client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/plr_iat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_iat/main.tf
@@ -101,12 +101,12 @@ module "service-account-roles" {
   }
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = false
   add_to_userinfo = false
   claim_name      = "preferred_username"
   client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = module.payara-client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/plr_rev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_rev/main.tf
@@ -101,12 +101,12 @@ module "service-account-roles" {
   }
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = false
   add_to_userinfo = false
   claim_name      = "preferred_username"
   client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = module.payara-client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
@@ -104,12 +104,12 @@ module "scope-mappings" {
   }
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = true
   add_to_userinfo = true
   claim_name      = "preferred_username"
   client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/sat-eforms/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sat-eforms/main.tf
@@ -67,12 +67,12 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "common_provider_numbe
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = true
   add_to_userinfo = true
   claim_name      = "preferred_username"
   client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }

--- a/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
@@ -53,12 +53,12 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   name                        = "client roles"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
+resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
   add_to_id_token = true
   add_to_userinfo = true
   claim_name      = "preferred_username"
   client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
+  name            = "phsa_windowsaccountname"
+  user_attribute  = "phsa_windowsaccountname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }


### PR DESCRIPTION
I missed Panorama in the previous PR: https://github.com/bcgov/moh-keycloak-client-configurations/pull/519