### PR TITLE
Remove PHSA windowaccountname mappers on all TEST clients.

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
@@ -47,13 +47,3 @@ module "client-roles" {
     },
   }
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/connect/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/connect/main.tf
@@ -70,13 +70,3 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/dht-dev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/dht-dev/main.tf
@@ -51,13 +51,3 @@ module "scope-mappings" {
     "LICENCE-STATUS/RNP"          = var.LICENCE-STATUS.ROLES["RNP"].id
   }
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/forms/main.tf
@@ -70,13 +70,3 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/gis/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/gis/main.tf
@@ -25,13 +25,3 @@ module "payara-client" {
     "https://gis.ynr9ed-test.nimbus.cloud.gov.bc.ca/gis/*",
   ]
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = false
-  add_to_userinfo = false
-  claim_name      = "preferred_username"
-  client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = module.payara-client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/hamis/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hamis/main.tf
@@ -99,13 +99,3 @@ module "service-account-roles" {
     }
   }
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = false
-  add_to_userinfo = false
-  claim_name      = "preferred_username"
-  client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = module.payara-client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hiat1/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hiat1/main.tf
@@ -70,13 +70,3 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = false
-  add_to_userinfo = false
-  claim_name      = "preferred_username"
-  client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = module.payara-client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hiat2/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hiat2/main.tf
@@ -70,13 +70,3 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = false
-  add_to_userinfo = false
-  claim_name      = "preferred_username"
-  client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = module.payara-client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hiat3/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hiat3/main.tf
@@ -70,13 +70,3 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = false
-  add_to_userinfo = false
-  claim_name      = "preferred_username"
-  client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = module.payara-client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hs1/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hs1/main.tf
@@ -70,13 +70,3 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = false
-  add_to_userinfo = false
-  claim_name      = "preferred_username"
-  client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = module.payara-client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_huat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_huat/main.tf
@@ -71,13 +71,3 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = false
-  add_to_userinfo = false
-  claim_name      = "preferred_username"
-  client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = module.payara-client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/hscis/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hscis/main.tf
@@ -86,13 +86,3 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = false
-  add_to_userinfo = false
-  claim_name      = "preferred_username"
-  client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = module.payara-client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
@@ -100,12 +100,3 @@ module "client-roles" {
     },
   }
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -156,12 +156,3 @@ module "client-roles" {
     },
   }
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/lra-dev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-dev/main.tf
@@ -52,13 +52,3 @@ module "scope-mappings" {
     "LICENCE-STATUS/RNP"          = var.LICENCE-STATUS.ROLES["RNP"].id
   }
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/miwt_stg/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/miwt_stg/main.tf
@@ -51,13 +51,3 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = false
-  add_to_userinfo = false
-  claim_name      = "preferred_username"
-  client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = module.payara-client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/moh-servicenow/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/moh-servicenow/main.tf
@@ -44,13 +44,3 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider"
   realm_id         = keycloak_openid_client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/panorama/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/panorama/main.tf
@@ -41,13 +41,3 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutnam
   user_attribute  = "phsa_windowsaccoutname"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/pidp-webapp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/pidp-webapp/main.tf
@@ -72,13 +72,3 @@ module "scope-mappings" {
     "account/view-profile"           = var.account.ROLES["view-profile"].id,
   }
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/plr_iat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_iat/main.tf
@@ -100,13 +100,3 @@ module "service-account-roles" {
     }
   }
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = false
-  add_to_userinfo = false
-  claim_name      = "preferred_username"
-  client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = module.payara-client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/plr_rev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_rev/main.tf
@@ -100,13 +100,3 @@ module "service-account-roles" {
     }
   }
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = false
-  add_to_userinfo = false
-  claim_name      = "preferred_username"
-  client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = module.payara-client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
@@ -103,13 +103,3 @@ module "scope-mappings" {
     "LICENCE-STATUS/RNP"                  = var.LICENCE-STATUS.ROLES["RNP"].id
   }
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/sat-eforms/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sat-eforms/main.tf
@@ -66,13 +66,3 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "common_provider_numbe
   user_attribute      = "common_provider_number"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
-
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
@@ -53,12 +53,3 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   name                        = "client roles"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccountname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccountname"
-  user_attribute  = "phsa_windowsaccountname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}


### PR DESCRIPTION
### Changes being made

Remove PHSA windowaccountname mappers on all TEST clients.

### Context

Rolling-back RFC-20240429-01-BCMOHAD-20395-TEST-KEYCLOAK-Change_PHSA_Username_Format.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
