### PR TITLE
create HIDES test client

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -113,6 +113,9 @@ module "HEM" {
 module "HHSLibrary" {
   source = "./clients/hhs-library"
 }
+module "HIDES" {
+  source = "./clients/hides"
+}
 module "HLBC" {
   source = "./clients/hlbc"
 }

--- a/keycloak-test/realms/moh_applications/clients/hides/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hides/main.tf
@@ -1,0 +1,61 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "HIDES"
+  consent_required                    = false
+  description                         = "HIDES - Health Ideas Data Extraction Service. A dotnet web frontend for building regular large extracts from the Healthideas data warehouse to external providers."
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "Health Ideas Data Extraction Service"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+    "http://localhost:*",
+    "https://localhost:*",
+    "https://devsecure.healthideas.gov.bc.ca/hides/*",
+    "https://uatsecure.healthideas.gov.bc.ca/uat/hides/*",
+    "https://uatsecure.healthideas.gov.bc.ca/acc/hides/*"
+  ]
+  web_origins = [
+    "+"
+  ]
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "idir_displayName" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "idir_displayName"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "idir_displayName"
+  user_attribute  = "idir_displayName"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "idir_username" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "idir_username"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "idir_username"
+  user_attribute  = "idir_username"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "idir_user_guid" {
+  add_to_id_token = true
+  add_to_userinfo = true
+  claim_name      = "idir_user_guid"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "idir_user_guid"
+  user_attribute  = "idir_user_guid"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-test/realms/moh_applications/clients/hides/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/hides/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/hides/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/hides/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Create HIDES client on Test environment.

### Context

Health Ideas Data Extraction Service, one of HealthIdeas applications. Same requirements and architecture as USAM application which is already integrated with Keycloak Test + Prod.

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided.
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 
- [x] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.

