### PR TITLE
import umc-e2e client roles and scope to terraform

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients.tf
+++ b/keycloak-dev/realms/moh_applications/clients.tf
@@ -142,7 +142,7 @@ module "USER-MANAGEMENT-SERVICE" {
   MSPDIRECT-SERVICE = module.MSPDIRECT-SERVICE
 }
 module "UMC-E2E-TESTS" {
-  source                  = "./clients/umc-e2e-tests"
+  source = "./clients/umc-e2e-tests"
 }
 module "UMS-INTEGRATION-TESTS" {
   source                  = "./clients/ums-integration-tests"

--- a/keycloak-dev/realms/moh_applications/clients.tf
+++ b/keycloak-dev/realms/moh_applications/clients.tf
@@ -141,6 +141,9 @@ module "USER-MANAGEMENT-SERVICE" {
   ORGANIZATIONS-API = module.ORGANIZATIONS-API
   MSPDIRECT-SERVICE = module.MSPDIRECT-SERVICE
 }
+module "UMC-E2E-TESTS" {
+  source                  = "./clients/umc-e2e-tests"
+}
 module "UMS-INTEGRATION-TESTS" {
   source                  = "./clients/ums-integration-tests"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE

--- a/keycloak-dev/realms/moh_applications/clients/umc-e2e-tests/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/umc-e2e-tests/main.tf
@@ -1,0 +1,40 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = "1800"
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = false
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "UMC-E2E-TESTS"
+  consent_required                    = false
+  description                         = "The purpouse of this client is to define roles, that are later assigned to test accounts in E2E tests."
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "UMC-E2E-TESTS"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+    "http://localhost:8080"
+  ]
+  web_origins = [
+    "+"
+  ]
+}
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "E2E-ROLE-1" = {
+      "name" = "E2E-ROLE-1"
+    },
+    "E2E-ROLE-2" = {
+      "name" = "E2E-ROLE-2"
+    }
+  }
+}

--- a/keycloak-dev/realms/moh_applications/clients/umc-e2e-tests/outputs.tf
+++ b/keycloak-dev/realms/moh_applications/clients/umc-e2e-tests/outputs.tf
@@ -1,0 +1,6 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}
+output "ROLES" {
+  value = module.client-roles.ROLES
+}

--- a/keycloak-dev/realms/moh_applications/clients/umc-e2e-tests/versions.tf
+++ b/keycloak-dev/realms/moh_applications/clients/umc-e2e-tests/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-dev/realms/moh_applications/clients/user-management-service/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/user-management-service/main.tf
@@ -94,6 +94,9 @@ module "client-roles" {
     "view-client-pho-rsc-groups" = {
       "name" = "view-client-pho-rsc-groups"
     },
+    "view-client-umc-e2e-tests" = {
+      "name" = "view-client-umc-e2e-tests"
+    },
     "view-client-ums-integration-tests" = {
       "name" = "view-client-ums-integration-tests"
     },

--- a/keycloak-dev/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/user-management/main.tf
@@ -62,6 +62,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/manage-own-groups"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     "USER-MANAGEMENT-SERVICE/manage-user-roles"                     = var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     "USER-MANAGEMENT-SERVICE/view-client-bcer-cp"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-umc-e2e-tests"             = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-umc-e2e-tests"].id,
     "USER-MANAGEMENT-SERVICE/view-client-dmft-webappp"              = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-dmft-webapp"].id,
     "USER-MANAGEMENT-SERVICE/view-client-emcod"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-emcod"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hcimweb"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb"].id,


### PR DESCRIPTION
### Changes being made

Importing UMC-E2E client, roles and scopes to UMS/UMC.

### Context

Importing manually created client to terraform, so that E2E UMC tests won't break again. The client is just a role holder used in e2e tests. Roles are assigned to the testcafe user.
Plan should only show scope mapping changes, as rest of the resources was imported. (Plus some minor updates to client config)

### Quality Check

- [ ] Client has Name and Description defined.
- [ ] Full Scope Allowed is disabled.
- [ ] Direct Access Grants Enabled is disabled.
- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [ ] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [ ] Client Scopes are not assigned to client, or explanation for doing so is provided.
- [ ] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 