### PR TITLE
Configure phlat service client

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients.tf
+++ b/keycloak-dev/realms/moh_applications/clients.tf
@@ -82,6 +82,10 @@ module "MSPDIRECT-WEB" {
 module "ORGANIZATIONS-API" {
   source = "./clients/organizations-api"
 }
+module "PHLAT-SERVICE" {
+  source = "./clients/phlat-service"
+  PLR = module.PLR
+}
 module "PHO-RSC" {
   source         = "./clients/pho-rsc"
   PHO-RSC-GROUPS = module.PHO-RSC-GROUPS

--- a/keycloak-dev/realms/moh_applications/clients.tf
+++ b/keycloak-dev/realms/moh_applications/clients.tf
@@ -84,7 +84,7 @@ module "ORGANIZATIONS-API" {
 }
 module "PHLAT-SERVICE" {
   source = "./clients/phlat-service"
-  PLR = module.PLR
+  PLR    = module.PLR
 }
 module "PHO-RSC" {
   source         = "./clients/pho-rsc"

--- a/keycloak-dev/realms/moh_applications/clients/phlat-service/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/phlat-service/main.tf
@@ -1,0 +1,59 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "PHLAT-SERVICE"
+  consent_required                    = false
+  description                         = "PLR Health Service Delivery Site Data Load Assistant Tool - Service Account Used for PLR MERGE(DEV) communication"
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "PHLAT-SERVICE"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = true
+  standard_flow_enabled               = false
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+resource "keycloak_openid_hardcoded_claim_protocol_mapper" "orgId" {
+  add_to_access_token = true
+  add_to_id_token     = true
+  add_to_userinfo     = true
+  claim_name          = "orgId"
+  claim_value         = "00002855"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "orgId"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+module "service-account-roles" {
+  source                  = "../../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {
+    "PLR/REG_ADMIN" = {
+      "client_id" = var.PLR.CLIENT.id,
+      "role_id"   = "REG_ADMIN"
+    }
+  }
+}
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "PLR/REG_ADMIN" = var.PLR.ROLES["REG_ADMIN"].id
+  }
+}

--- a/keycloak-dev/realms/moh_applications/clients/phlat-service/outputs.tf
+++ b/keycloak-dev/realms/moh_applications/clients/phlat-service/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-dev/realms/moh_applications/clients/phlat-service/variables.tf
+++ b/keycloak-dev/realms/moh_applications/clients/phlat-service/variables.tf
@@ -1,0 +1,1 @@
+variable "PLR" {}

--- a/keycloak-dev/realms/moh_applications/clients/phlat-service/versions.tf
+++ b/keycloak-dev/realms/moh_applications/clients/phlat-service/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -207,8 +207,8 @@ module "PANORAMA" {
   source = "./clients/panorama"
 }
 module "PHLAT-SERVICE" {
-  source = "./clients/phlat-service"
-    PLR_CONF = module.PLR_CONF
+  source   = "./clients/phlat-service"
+  PLR_CONF = module.PLR_CONF
 }
 module "PHLAT-WEB" {
   source = "./clients/phlat-web"

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -208,6 +208,7 @@ module "PANORAMA" {
 }
 module "PHLAT-SERVICE" {
   source = "./clients/phlat-service"
+    PLR_CONF = module.PLR_CONF
 }
 module "PHLAT-WEB" {
   source = "./clients/phlat-web"

--- a/keycloak-test/realms/moh_applications/clients/phlat-service/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/phlat-service/variables.tf
@@ -1,0 +1,1 @@
+variable "PLR_CONF" {}


### PR DESCRIPTION
### Changes being made

Creating PHLAT-SERVICE client on Keycloak dev.
Updating PHLAT-SERVICE client on Keycloak test.

### Context

Those clients are used to call PLR (Merge and CONF environments) with REG_ADMIN role. 

### Quality Check

- [ ] Client has Name and Description defined.
- [ ] Full Scope Allowed is disabled.
- [ ] Direct Access Grants Enabled is disabled.
- [ ] Client Scopes are not assigned to client, or explanation for doing so is provided. 
- [ ] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 


