### PR TITLE
add salesforce apps urls

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/icy/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/icy/main.tf
@@ -22,7 +22,8 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://bcmohmaid--maiduat.my.salesforce.com/*",
     "https://bcmohmaid--maidqa.my.salesforce.com/*",
     "https://bcmohmaid--maiduat.sandbox.my.salesforce.com/*",
-    "https://bcmohmaid--maidqa.sandbox.my.salesforce.com/*"
+    "https://bcmohmaid--maidqa.sandbox.my.salesforce.com/*",
+    "https://bcmohmaid--soseuat.sandbox.my.salesforce.com/*"
   ]
   web_origins = [
   ]

--- a/keycloak-test/realms/moh_applications/clients/maid/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/maid/main.tf
@@ -24,7 +24,8 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://bcmohmaid--maidqa.my.salesforce.com/*",
     "https://healthbc--pmycareidp.sandbox.my.site.com/*",
     "https://bcmohmaid--maiduat.sandbox.my.salesforce.com/*",
-    "https://bcmohmaid--maidqa.sandbox.my.salesforce.com/*"
+    "https://bcmohmaid--maidqa.sandbox.my.salesforce.com/*",
+    "https://bcmohmaid--soseuat.sandbox.my.salesforce.com/*"
   ]
   web_origins = [
   ]

--- a/keycloak-test/realms/moh_applications/clients/sa-dbaac-portal/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sa-dbaac-portal/main.tf
@@ -17,7 +17,8 @@ module "payara-client" {
   valid_redirect_uris = [
     "https://pwcdev-bchealth.cs142.force.com/DBAACEC/services/authcallback/Login_with_IDIR_DBAACEC",
     "https://staging-bchealth.cs148.force.com/DBAACEC/services/authcallback/Login_with_IDIR_DBAACEC",
-    "https://staging-bchealth.cs148.sandbox.my.site.com/DBAACEC/services/authcallback/Login_with_IDIR_DBAACEC"
+    "https://staging-bchealth.cs148.sandbox.my.site.com/DBAACEC/services/authcallback/Login_with_IDIR_DBAACEC",
+    "https://bchealth--satdevorg.sandbox.my.salesforce.com/*"
   ]
 }
 resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {

--- a/keycloak-test/realms/moh_applications/clients/sa-hibc-service-bc-portal/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sa-hibc-service-bc-portal/main.tf
@@ -20,7 +20,8 @@ module "payara-client" {
   valid_redirect_uris = [
     "https://pwcdev-bchealth.cs142.force.com/services/authcallback/Login_with_IDIR_HIBCSBC",
     "https://staging-bchealth.cs148.force.com/services/authcallback/Login_with_IDIR_HIBCSBC",
-    "https://staging-bchealth.cs148.sandbox.my.site.com/services/authcallback/Login_with_IDIR_HIBCSBC"
+    "https://staging-bchealth.cs148.sandbox.my.site.com/services/authcallback/Login_with_IDIR_HIBCSBC",
+    "https://bchealth--satdevorg.sandbox.my.salesforce.com/*"
   ]
 }
 resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {

--- a/keycloak-test/realms/moh_applications/clients/sa-sfdc/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sa-sfdc/main.tf
@@ -28,7 +28,8 @@ module "payara-client" {
     "https://bchealth--staging.my.salesforce.com/services/authcallback/Login_with_IDIR",
     "https://bchealth--staging.sandbox.my.salesforce.com/services/authcallback/Login_with_IDIR",
     "https://bchealth--staging.sandbox.my.site.com/services/authcallback/Login_with_IDIR",
-    "https://bchealth--satqa.sandbox.my.salesforce.com/*"
+    "https://bchealth--satqa.sandbox.my.salesforce.com/*",
+    "https://bchealth--satdevorg.sandbox.my.salesforce.com/*"
   ]
 }
 resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {


### PR DESCRIPTION
### Changes being made

Adding URLs to CGI-managed Salesforce apps in Keycloak Test

### Context
Please find the client IDs for test environments:
For SATDevOrg: 
SA-SFDC
SA-HIBC-SERVICE-BC-PORTAL
SA-DBAAC-PORTAL

For SOSEUAT:
ICY
MAiD 

and URLs for test environments:
https://bchealth--satdevorg.sandbox.my.salesforce.com/
https://bcmohmaid--soseuat.sandbox.my.salesforce.com/

### Quality Check

- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.