### PR TITLE
fix url typo

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/hides/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hides/main.tf
@@ -22,8 +22,8 @@ resource "keycloak_openid_client" "CLIENT" {
     "http://localhost:*",
     "https://localhost:*",
     "https://devsecure.healthideas.gov.bc.ca/hides/*",
-    "https://uatsecure.heaalthideas.gov.bc.ca/hidesuat/*",
-    "https://uatsecure.heaalthideas.gov.bc.ca/hidesacc/*"
+    "https://uatsecure.healthideas.gov.bc.ca/hidesuat/*",
+    "https://uatsecure.healthideas.gov.bc.ca/hidesacc/*"
   ]
   web_origins = [
     "+"


### PR DESCRIPTION
### Changes being made

Update URLs for HIDES application.

### Context

Client provided URLs with a typo and I did not notice.

### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 