### PR TITLE
Remove phsa_windowsaccoutname mappers on DEV.

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/bcer-cp/main.tf
@@ -45,12 +45,3 @@ module "client-roles" {
     },
   }
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-dev/realms/moh_applications/clients/connect/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/connect/main.tf
@@ -69,12 +69,3 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-dev/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/forms/main.tf
@@ -69,12 +69,3 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-dev/realms/moh_applications/clients/hcimweb/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/hcimweb/main.tf
@@ -75,12 +75,3 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
-  add_to_id_token = false
-  add_to_userinfo = false
-  claim_name      = "preferred_username"
-  client_id       = module.payara-client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
-  realm_id        = module.payara-client.CLIENT.realm_id
-}

--- a/keycloak-dev/realms/moh_applications/clients/moh-servicenow/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/moh-servicenow/main.tf
@@ -42,12 +42,3 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider"
   realm_id         = keycloak_openid_client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-dev/realms/moh_applications/clients/pidp-webapp/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pidp-webapp/main.tf
@@ -355,12 +355,3 @@ module "scope-mappings" {
     "account/view-profile"           = var.account.ROLES["view-profile"].id,
   }
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-dev/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/prp-web/main.tf
@@ -55,12 +55,3 @@ module "scope-mappings" {
     "PRP-SERVICE/MSPQI"      = var.PRP-SERVICE.ROLES["MSPQI"].id,
   }
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}

--- a/keycloak-test/realms/moh_applications/clients/panorama/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/panorama/main.tf
@@ -32,12 +32,3 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider"
   realm_id         = keycloak_openid_client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
-resource "keycloak_openid_user_attribute_protocol_mapper" "phsa_windowsaccoutname" {
-  add_to_id_token = true
-  add_to_userinfo = true
-  claim_name      = "preferred_username"
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "phsa_windowsaccoutname"
-  user_attribute  = "phsa_windowsaccoutname"
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-}


### PR DESCRIPTION
### Changes being made

Remove phsa_windowsaccoutname mappers on DEV.

### Context

Remove phsa_windowsaccoutname mappers on DEV. The mappers will later be recreated using a custom Override OIDC User Attribute Mapper. Note that this also removes the typo.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
