### PR TITLE
Add Client-ID mapper to the PHLAT service account in DEV and TEST.

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/phlat-service/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/phlat-service/main.tf
@@ -34,6 +34,33 @@ resource "keycloak_openid_hardcoded_claim_protocol_mapper" "orgId" {
   name                = "orgId"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
+resource "keycloak_openid_user_session_note_protocol_mapper" "Client-Host" {
+  add_to_id_token  = true
+  claim_name       = "clientHost"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "Client Host"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "clientHost"
+}
+resource "keycloak_openid_user_session_note_protocol_mapper" "Client-ID" {
+  add_to_id_token  = true
+  claim_name       = "clientId"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "Client ID"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "clientId"
+}
+resource "keycloak_openid_user_session_note_protocol_mapper" "Client-IP-Address" {
+  add_to_id_token  = true
+  claim_name       = "clientAddress"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "Client IP Address"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "clientAddress"
+}
 module "service-account-roles" {
   source                  = "../../../../../modules/service-account-roles"
   realm_id                = keycloak_openid_client.CLIENT.realm_id

--- a/keycloak-test/realms/moh_applications/clients/phlat-service/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/phlat-service/main.tf
@@ -34,6 +34,33 @@ resource "keycloak_openid_hardcoded_claim_protocol_mapper" "orgId" {
   name                = "orgId"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
+resource "keycloak_openid_user_session_note_protocol_mapper" "Client-Host" {
+  add_to_id_token  = true
+  claim_name       = "clientHost"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "Client Host"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "clientHost"
+}
+resource "keycloak_openid_user_session_note_protocol_mapper" "Client-ID" {
+  add_to_id_token  = true
+  claim_name       = "clientId"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "Client ID"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "clientId"
+}
+resource "keycloak_openid_user_session_note_protocol_mapper" "Client-IP-Address" {
+  add_to_id_token  = true
+  claim_name       = "clientAddress"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "Client IP Address"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "clientAddress"
+}
 module "service-account-roles" {
   source                  = "../../../../../modules/service-account-roles"
   realm_id                = keycloak_openid_client.CLIENT.realm_id


### PR DESCRIPTION
### Changes being made

Add Client-ID mapper to the PHLAT service account in DEV and TEST.

### Context

PLR-ESB uses the client-id for some reason. Somewhere in the Keycloak 18 to 22 version upgrade, they changed the default from clientId to client_id to be spec compliant, so to use the old value we must manually specify it.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
