### PR TITLE
Add the phsa_windowsaccountname to the FORMS DEV client using the new oidc-override-usermodel-attribute-mapper.

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/forms/main.tf
@@ -69,3 +69,19 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
+
+resource "keycloak_generic_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "phsa_windowsaccountname"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-dev/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/forms/main.tf
@@ -70,7 +70,7 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
   ]
 }
 
-resource "keycloak_generic_protocol_mapper" "phsa_windowsaccountname" {
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
   client_id       = keycloak_openid_client.CLIENT.id
   name            = "phsa_windowsaccountname"


### PR DESCRIPTION
### Changes being made

Add the phsa_windowsaccountname to the FORMS DEV client using the new oidc-override-usermodel-attribute-mapper.

### Context

Part of the PHSA Entra ID username format change.

### Quality Check
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
