### PR TITLE
Add phsa_windowsaccountname mapper to all DEV clients with HA logins.

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/bcer-cp/main.tf
@@ -45,3 +45,18 @@ module "client-roles" {
     },
   }
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-dev/realms/moh_applications/clients/connect/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/connect/main.tf
@@ -69,3 +69,18 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-dev/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/forms/main.tf
@@ -69,22 +69,6 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
-
-resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "preferred_username"
-  protocol        = "openid-connect"
-  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
-  config = {
-    "userinfo.token.claim" : "false",
-    "user.attribute" : "phsa_windowsaccountname",
-    "id.token.claim" : "true",
-    "access.token.claim" : "true",
-    "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
-  }
-}
 resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
   client_id       = keycloak_openid_client.CLIENT.id

--- a/keycloak-dev/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/forms/main.tf
@@ -85,3 +85,18 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "jsonType.label" : "String"
   }
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-dev/realms/moh_applications/clients/hcimweb/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/hcimweb/main.tf
@@ -75,3 +75,18 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-dev/realms/moh_applications/clients/moh-servicenow/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/moh-servicenow/main.tf
@@ -42,3 +42,18 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider"
   realm_id         = keycloak_openid_client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-dev/realms/moh_applications/clients/pidp-webapp/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pidp-webapp/main.tf
@@ -355,3 +355,18 @@ module "scope-mappings" {
     "account/view-profile"           = var.account.ROLES["view-profile"].id,
   }
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-dev/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/prp-web/main.tf
@@ -55,3 +55,18 @@ module "scope-mappings" {
     "PRP-SERVICE/MSPQI"      = var.PRP-SERVICE.ROLES["MSPQI"].id,
   }
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}


### PR DESCRIPTION
### Changes being made

Add phsa_windowsaccountname mapper to all DEV clients with HA logins.

### Context

Part of the PHSA Entra ID integration epic.

### Quality Check
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
