### PR TITLE
import genesys client to terraform

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -63,6 +63,9 @@ module "FMDB" {
 module "FORMS" {
   source = "./clients/forms"
 }
+module "GENESYS" {
+  source = "./clients/genesys"
+}
 module "GIS" {
   source = "./clients/gis"
 }

--- a/keycloak-test/realms/moh_applications/clients/genesys/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/genesys/main.tf
@@ -49,6 +49,6 @@ resource "keycloak_saml_user_attribute_protocol_mapper" "saml_user_attribute_map
   name                       = "email"
   user_attribute             = "email"
   saml_attribute_name        = "email"
-  friendly_name = "email"
+  friendly_name              = "email"
   saml_attribute_name_format = "Basic"
 }

--- a/keycloak-test/realms/moh_applications/clients/genesys/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/genesys/main.tf
@@ -1,0 +1,54 @@
+resource "keycloak_saml_client" "CLIENT" {
+  realm_id                  = "moh_applications"
+  client_id                 = "GENESYS"
+  name                      = "GENESYS"
+  description               = "Contact Center as a Service (CCaaS) Genesys CX Cloud contact center solution"
+  enabled                   = true
+  include_authn_statement   = true
+  sign_documents            = true
+  sign_assertions           = false
+  signature_algorithm       = "RSA_SHA256"
+  signature_key_name        = "NONE"
+  canonicalization_method   = "EXCLUSIVE"
+  encrypt_assertions        = false
+  client_signature_required = false
+  force_post_binding        = true
+  front_channel_logout      = true
+  force_name_id_format      = false
+  name_id_format            = "persistent"
+  full_scope_allowed        = false
+
+  valid_redirect_uris = [
+    "https://login.cac1.pure.cloud/*"
+  ]
+  base_url = "https://login.cac1.pure.cloud"
+
+  assertion_consumer_redirect_url     = "https://login.cac1.pure.cloud/saml"
+  assertion_consumer_post_url         = "https://login.cac1.pure.cloud/saml"
+  logout_service_redirect_binding_url = "https://login.cac1.pure.cloud/saml/logout"
+  logout_service_post_binding_url     = "https://login.cac1.pure.cloud/saml/logout"
+}
+
+resource "keycloak_generic_client_protocol_mapper" "saml_hardcoded_attribute_mapper" {
+  realm_id        = keycloak_saml_client.CLIENT.realm_id
+  client_id       = keycloak_saml_client.CLIENT.id
+  name            = "OrganizationName"
+  protocol        = "saml"
+  protocol_mapper = "saml-hardcode-attribute-mapper"
+  config = {
+    "attribute.name"       = "OrganizationName"
+    "attribute.nameformat" = "Basic"
+    "attribute.value"      = "hlbc-dev"
+    "friendly.name"        = "OrganizationName"
+  }
+}
+
+resource "keycloak_saml_user_attribute_protocol_mapper" "saml_user_attribute_mapper" {
+  realm_id                   = keycloak_saml_client.CLIENT.realm_id
+  client_id                  = keycloak_saml_client.CLIENT.id
+  name                       = "email"
+  user_attribute             = "email"
+  saml_attribute_name        = "email"
+  friendly_name = "email"
+  saml_attribute_name_format = "Basic"
+}

--- a/keycloak-test/realms/moh_applications/clients/genesys/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/genesys/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_saml_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/genesys/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/genesys/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Importing GENESYS client to terraform. This SAML client was created manually and tested on Keycloak Test environment. 
This PR's goal is only to add terraform configuration code. 

### Context

Onboarding of Genesys to Keycloak.
The resources have been already imported to tf state file, so plan should not show any changes, apart from the hardcoded SAML attribute mapper - I made a typo when creating it manually so in Keycloak it's called "OrganizationName " instead of "OrganizationName". One mapper starts from the uppercase (OrganizationName) and other from lower case (email) -> that's what I've been given in the documentation by Genesys team.

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. 
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.
- [x] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
