### PR TITLE
Remove bcprovider_lab realm from the TEST event config because it doe…

### DIFF
--- a/keycloak-test/events.tf
+++ b/keycloak-test/events.tf
@@ -165,23 +165,6 @@ resource "keycloak_realm_events" "realm_events_bcprovider_aad" {
   ]
 }
 
-resource "keycloak_realm_events" "realm_events_bcproviderlab_aad" {
-  realm_id = "bcproviderlab_aad"
-
-  events_enabled    = false
-  events_expiration = local.seconds_in_a_year
-
-  admin_events_enabled         = true
-  admin_events_details_enabled = true
-
-  # When omitted or left empty, keycloak will enable all event types
-  enabled_event_types = local.event_types
-
-  events_listeners = [
-    "jboss-logging", # keycloak enables the 'jboss-logging' event listener by default.
-  ]
-}
-
 resource "keycloak_realm_events" "realm_events_bcsc" {
   realm_id = "bcsc"
 


### PR DESCRIPTION
### Changes being made

Remove bcprovider_lab realm from the TEST event config because it doesn't exist.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
