### PR TITLE
Extend login event retention to three years in DEV and TEST.

### DIFF
--- a/keycloak-dev/events.tf
+++ b/keycloak-dev/events.tf
@@ -19,7 +19,7 @@ locals {
     "VALIDATE_ACCESS_TOKEN_ERROR"
   ]
   seconds_in_a_year      = 31536000
-  seconds_in_three_years = seconds_in_a_year * 3
+  seconds_in_three_years = local.seconds_in_a_year * 3
 }
 
 ######################

--- a/keycloak-dev/events.tf
+++ b/keycloak-dev/events.tf
@@ -19,6 +19,7 @@ locals {
     "VALIDATE_ACCESS_TOKEN_ERROR"
   ]
   seconds_in_a_year = 31536000
+  seconds_in_three_years = seconds_in_a_year * 3
 }
 
 ######################
@@ -29,7 +30,7 @@ resource "keycloak_realm_events" "realm_events_bcerd" {
   realm_id = "bcerd"
 
   events_enabled    = true
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -46,7 +47,7 @@ resource "keycloak_realm_events" "realm_events_lra" {
   realm_id = "lra"
 
   events_enabled    = true
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -63,7 +64,7 @@ resource "keycloak_realm_events" "realm_events_master" {
   realm_id = "master"
 
   events_enabled    = true
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -80,7 +81,7 @@ resource "keycloak_realm_events" "realm_events_mhsu_foundry" {
   realm_id = "mhsu_foundry"
 
   events_enabled    = true
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -97,7 +98,7 @@ resource "keycloak_realm_events" "realm_events_moh_applications" {
   realm_id = "moh_applications"
 
   events_enabled    = true
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -114,7 +115,7 @@ resource "keycloak_realm_events" "realm_events_moh_citizen" {
   realm_id = "moh_citizen"
 
   events_enabled    = true
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -131,7 +132,7 @@ resource "keycloak_realm_events" "realm_events_pidp_sandbox" {
   realm_id = "pidp_sandbox"
 
   events_enabled    = true
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -148,7 +149,7 @@ resource "keycloak_realm_events" "realm_events_v2_pos" {
   realm_id = "v2_pos"
 
   events_enabled    = true
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -169,7 +170,7 @@ resource "keycloak_realm_events" "realm_events_bceid_basic" {
   realm_id = "bceid_basic"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -186,7 +187,7 @@ resource "keycloak_realm_events" "realm_events_bceid_business" {
   realm_id = "bceid_business"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -203,7 +204,7 @@ resource "keycloak_realm_events" "realm_events_bcprovider_aad" {
   realm_id = "bcprovider_aad"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -220,7 +221,7 @@ resource "keycloak_realm_events" "realm_events_bcproviderlab_aad" {
   realm_id = "bcproviderlab_aad"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -237,7 +238,7 @@ resource "keycloak_realm_events" "realm_events_bcsc" {
   realm_id = "bcsc"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -254,7 +255,7 @@ resource "keycloak_realm_events" "realm_events_fnha_aad" {
   realm_id = "fnha_aad"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -271,7 +272,7 @@ resource "keycloak_realm_events" "realm_events_idir" {
   realm_id = "idir"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -288,7 +289,7 @@ resource "keycloak_realm_events" "realm_events_idir_aad" {
   realm_id = "idir_aad"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -305,7 +306,7 @@ resource "keycloak_realm_events" "realm_events_moh_idp" {
   realm_id = "moh_idp"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -322,7 +323,7 @@ resource "keycloak_realm_events" "realm_events_phsa" {
   realm_id = "phsa"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -339,7 +340,7 @@ resource "keycloak_realm_events" "realm_events_phsa_aad" {
   realm_id = "phsa_aad"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true

--- a/keycloak-dev/events.tf
+++ b/keycloak-dev/events.tf
@@ -18,7 +18,7 @@ locals {
     "VALIDATE_ACCESS_TOKEN",
     "VALIDATE_ACCESS_TOKEN_ERROR"
   ]
-  seconds_in_a_year = 31536000
+  seconds_in_a_year      = 31536000
   seconds_in_three_years = seconds_in_a_year * 3
 }
 

--- a/keycloak-test/events.tf
+++ b/keycloak-test/events.tf
@@ -19,7 +19,7 @@ locals {
     "VALIDATE_ACCESS_TOKEN_ERROR"
   ]
   seconds_in_a_year      = 31536000
-  seconds_in_three_years = seconds_in_a_year * 3
+  seconds_in_three_years = local.seconds_in_a_year * 3
 }
 
 ######################

--- a/keycloak-test/events.tf
+++ b/keycloak-test/events.tf
@@ -19,6 +19,7 @@ locals {
     "VALIDATE_ACCESS_TOKEN_ERROR"
   ]
   seconds_in_a_year = 31536000
+  seconds_in_three_years = seconds_in_a_year * 3
 }
 
 ######################
@@ -29,7 +30,7 @@ resource "keycloak_realm_events" "realm_events_bcer" {
   realm_id = "bcer"
 
   events_enabled    = true
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -46,7 +47,7 @@ resource "keycloak_realm_events" "realm_events_master" {
   realm_id = "master"
 
   events_enabled    = true
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -63,7 +64,7 @@ resource "keycloak_realm_events" "realm_events_mhsu_foundry" {
   realm_id = "mhsu_foundry"
 
   events_enabled    = true
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -80,7 +81,7 @@ resource "keycloak_realm_events" "realm_events_moh_applications" {
   realm_id = "moh_applications"
 
   events_enabled    = true
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -97,7 +98,7 @@ resource "keycloak_realm_events" "realm_events_moh_citizen" {
   realm_id = "moh_citizen"
 
   events_enabled    = true
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -118,7 +119,7 @@ resource "keycloak_realm_events" "realm_events_bceid_basic" {
   realm_id = "bceid_basic"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -135,7 +136,7 @@ resource "keycloak_realm_events" "realm_events_bceid_business" {
   realm_id = "bceid_business"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -152,7 +153,7 @@ resource "keycloak_realm_events" "realm_events_bcprovider_aad" {
   realm_id = "bcprovider_aad"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -169,7 +170,7 @@ resource "keycloak_realm_events" "realm_events_bcproviderlab_aad" {
   realm_id = "bcproviderlab_aad"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -186,7 +187,7 @@ resource "keycloak_realm_events" "realm_events_bcsc" {
   realm_id = "bcsc"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -203,7 +204,7 @@ resource "keycloak_realm_events" "realm_events_fnha_aad" {
   realm_id = "fnha_aad"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -220,7 +221,7 @@ resource "keycloak_realm_events" "realm_events_idir" {
   realm_id = "idir"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -237,7 +238,7 @@ resource "keycloak_realm_events" "realm_events_idir_aad" {
   realm_id = "idir_aad"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -254,7 +255,7 @@ resource "keycloak_realm_events" "realm_events_moh_idp" {
   realm_id = "moh_idp"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -271,7 +272,7 @@ resource "keycloak_realm_events" "realm_events_phsa" {
   realm_id = "phsa"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true
@@ -288,7 +289,7 @@ resource "keycloak_realm_events" "realm_events_phsa_aad" {
   realm_id = "phsa_aad"
 
   events_enabled    = false
-  events_expiration = local.seconds_in_a_year
+  events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true
   admin_events_details_enabled = true

--- a/keycloak-test/events.tf
+++ b/keycloak-test/events.tf
@@ -18,7 +18,7 @@ locals {
     "VALIDATE_ACCESS_TOKEN",
     "VALIDATE_ACCESS_TOKEN_ERROR"
   ]
-  seconds_in_a_year = 31536000
+  seconds_in_a_year      = 31536000
   seconds_in_three_years = seconds_in_a_year * 3
 }
 


### PR DESCRIPTION
### Changes being made

Extend login event retention to three years in DEV and TEST.

### Context

OCIO information retention schedule compliance.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
