### PR TITLE
TEST env: Add phsa_windowsaccountname to all clients that use HA login.

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
@@ -47,3 +47,19 @@ module "client-roles" {
     },
   }
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/connect/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/connect/main.tf
@@ -70,3 +70,19 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/dht-dev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/dht-dev/main.tf
@@ -51,3 +51,19 @@ module "scope-mappings" {
     "LICENCE-STATUS/RNP"          = var.LICENCE-STATUS.ROLES["RNP"].id
   }
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/forms/main.tf
@@ -70,3 +70,19 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/gis/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/gis/main.tf
@@ -25,3 +25,19 @@ module "payara-client" {
     "https://gis.ynr9ed-test.nimbus.cloud.gov.bc.ca/gis/*",
   ]
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/hamis/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hamis/main.tf
@@ -99,3 +99,19 @@ module "service-account-roles" {
     }
   }
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hiat1/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hiat1/main.tf
@@ -70,3 +70,19 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hiat2/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hiat2/main.tf
@@ -70,3 +70,19 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hiat3/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hiat3/main.tf
@@ -70,3 +70,19 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hs1/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hs1/main.tf
@@ -70,3 +70,19 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_huat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_huat/main.tf
@@ -71,3 +71,19 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/hscis/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hscis/main.tf
@@ -86,3 +86,19 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
@@ -125,3 +125,18 @@ module "client-roles" {
     }
   }
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -159,3 +159,18 @@ module "client-roles" {
     },
   }
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/lra-dev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-dev/main.tf
@@ -52,3 +52,19 @@ module "scope-mappings" {
     "LICENCE-STATUS/RNP"          = var.LICENCE-STATUS.ROLES["RNP"].id
   }
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/miwt_stg/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/miwt_stg/main.tf
@@ -51,3 +51,19 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/moh-servicenow/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/moh-servicenow/main.tf
@@ -44,3 +44,19 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider"
   realm_id         = keycloak_openid_client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/panorama/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/panorama/main.tf
@@ -32,3 +32,19 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider"
   realm_id         = keycloak_openid_client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/pidp-webapp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/pidp-webapp/main.tf
@@ -72,3 +72,19 @@ module "scope-mappings" {
     "account/view-profile"           = var.account.ROLES["view-profile"].id,
   }
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/plr_iat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_iat/main.tf
@@ -100,3 +100,19 @@ module "service-account-roles" {
     }
   }
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/plr_rev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_rev/main.tf
@@ -100,3 +100,19 @@ module "service-account-roles" {
     }
   }
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
@@ -103,3 +103,19 @@ module "scope-mappings" {
     "LICENCE-STATUS/RNP"                  = var.LICENCE-STATUS.ROLES["RNP"].id
   }
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/sat-eforms/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sat-eforms/main.tf
@@ -66,3 +66,19 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "common_provider_numbe
   user_attribute      = "common_provider_number"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
@@ -53,3 +53,18 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   name                        = "client roles"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}


### PR DESCRIPTION
### Changes being made

TEST env: Add phsa_windowsaccountname to all clients that use HA login.

### Context

RFC-20240429-01-BCMOHAD-20395-TEST-KEYCLOAK-Change_PHSA_Username_Format

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
