### PR TITLE
Adding dmz1/dmz2 valid redirect URIs for UMC

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/user-management/main.tf
@@ -20,6 +20,8 @@ resource "keycloak_openid_client" "CLIENT" {
   use_refresh_tokens                  = true
   valid_redirect_uris = [
     "https://user-management.hlth.gov.bc.ca/*",
+    "https://dmz1.user-management.hlth.gov.bc.ca/*",
+    "https://dmz2.user-management.hlth.gov.bc.ca/*",
   ]
   web_origins = [
     "+",

--- a/keycloak-test/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management/main.tf
@@ -20,6 +20,8 @@ resource "keycloak_openid_client" "CLIENT" {
   use_refresh_tokens                  = true
   valid_redirect_uris = [
     "https://user-management-test.hlth.gov.bc.ca/*",
+    "https://dmz1.user-management-test.hlth.gov.bc.ca/*",
+    "https://dmz2.user-management-test.hlth.gov.bc.ca/*",
   ]
   web_origins = [
     "+",


### PR DESCRIPTION
### Changes being made

Adding dmz1/dmz2 valid redirect URIs for UMC.

### Context

UMC doesn't have a `ROUTEID` cookie for us to switch instances.

### Quality Check

- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
