### PR TITLE
add WEBCAPS redirect

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/webcaps/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/webcaps/main.tf
@@ -20,6 +20,7 @@ resource "keycloak_openid_client" "CLIENT" {
   use_refresh_tokens                  = true
   valid_redirect_uris = [
     "https://public.healthideas.gov.bc.ca/*",
+    "https://publict.healthideas.gov.bc.ca/*"
   ]
   web_origins = [
   ]

--- a/keycloak-test/events.tf
+++ b/keycloak-test/events.tf
@@ -254,7 +254,7 @@ resource "keycloak_realm_events" "realm_events_moh_idp" {
 resource "keycloak_realm_events" "realm_events_phsa" {
   realm_id = "phsa"
 
-  events_enabled    = false
+  events_enabled    = true
   events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true

--- a/keycloak-test/realms/moh_applications/clients/genesys/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/genesys/main.tf
@@ -19,9 +19,10 @@ resource "keycloak_saml_client" "CLIENT" {
   full_scope_allowed        = false
 
   valid_redirect_uris = [
-    "https://login.cac1.pure.cloud/*"
+    "https://login.cac1.pure.cloud/*",
+    "https://apps.cac1.pure.cloud/*"
   ]
-  base_url = "https://login.cac1.pure.cloud"
+  base_url = "https://apps.cac1.pure.cloud/"
 
   assertion_consumer_redirect_url     = "https://login.cac1.pure.cloud/saml"
   assertion_consumer_post_url         = "https://login.cac1.pure.cloud/saml"


### PR DESCRIPTION
### Changes being made

Adding redirect URL for WEBCAPS. Enabling events logging in phsa realm.
Updating GENESYS URLs.

### Context

WEBCAPS changing servers - need to validate different envs.
Genesys client asked for the change so that user get's redirected to a subpage of an application (apps domain) instead of a welcome screen)

### Quality Check

- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.