### PR TITLE
TEST: Remove Panorma PHSA username override mapper.

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/panorama/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/panorama/main.tf
@@ -32,19 +32,3 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider"
   realm_id         = keycloak_openid_client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
-
-resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "preferred_username"
-  protocol        = "openid-connect"
-  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
-  config = {
-    "userinfo.token.claim" : "true",
-    "user.attribute" : "phsa_windowsaccountname",
-    "id.token.claim" : "true",
-    "access.token.claim" : "true",
-    "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
-  }
-}


### PR DESCRIPTION
### Changes being made

Remove Panorma PHSA username override mapper.

### Context

Panorama is not in PROD on Keycloak, so they can use the new format right from the start after doing a username migration. Fiona requests the default configuration.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
