### PR TITLE
Disable PHSA login event loggin in the TEST realm.

### DIFF
--- a/keycloak-test/events.tf
+++ b/keycloak-test/events.tf
@@ -254,7 +254,7 @@ resource "keycloak_realm_events" "realm_events_moh_idp" {
 resource "keycloak_realm_events" "realm_events_phsa" {
   realm_id = "phsa"
 
-  events_enabled    = true
+  events_enabled    = false
   events_expiration = local.seconds_in_three_years
 
   admin_events_enabled         = true


### PR DESCRIPTION
### Changes being made

Disable PHSA login event loggin in the TEST realm.

### Context

Login events are not recorded in IDP realms because it is mostly redundant as they already appear in moh_applications for real use. I enabled them for debugging purposes, which is no longer needed.

### Quality Check
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
