### PR TITLE
Rename "MoH ServiceNow" to "HLTH ServiceNow" as per Brad Allerton

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/moh-servicenow/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/moh-servicenow/main.tf
@@ -5,13 +5,13 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type    = "client-secret"
   client_id                    = "MOH-SERVICENOW"
   consent_required             = false
-  description                  = "MoH Health eServices Portal"
+  description                  = "Health eServices Portal"
   direct_access_grants_enabled = false
   enabled                      = true
   frontchannel_logout_enabled  = false
   full_scope_allowed           = false
   implicit_flow_enabled        = false
-  name                         = "MoH ServiceNow"
+  name                         = "HLTH ServiceNow"
   pkce_code_challenge_method   = ""
   realm_id                     = "moh_applications"
   service_accounts_enabled     = false

--- a/keycloak-prod/realms/moh_applications/clients/moh-servicenow/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/moh-servicenow/main.tf
@@ -5,13 +5,13 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type    = "client-secret"
   client_id                    = "MOH-SERVICENOW"
   consent_required             = false
-  description                  = "MoH Health eServices Portal"
+  description                  = "Health eServices Portal"
   direct_access_grants_enabled = false
   enabled                      = true
   frontchannel_logout_enabled  = false
   full_scope_allowed           = false
   implicit_flow_enabled        = false
-  name                         = "MoH ServiceNow"
+  name                         = "HLTH ServiceNow"
   pkce_code_challenge_method   = ""
   realm_id                     = "moh_applications"
   service_accounts_enabled     = false

--- a/keycloak-test/realms/moh_applications/clients/moh-servicenow/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/moh-servicenow/main.tf
@@ -5,13 +5,13 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type    = "client-secret"
   client_id                    = "MOH-SERVICENOW"
   consent_required             = false
-  description                  = "MoH Health eServices Portal"
+  description                  = "Health eServices Portal"
   direct_access_grants_enabled = false
   enabled                      = true
   frontchannel_logout_enabled  = false
   full_scope_allowed           = false
   implicit_flow_enabled        = false
-  name                         = "MoH ServiceNow"
+  name                         = "HLTH ServiceNow"
   pkce_code_challenge_method   = ""
   realm_id                     = "moh_applications"
   service_accounts_enabled     = false


### PR DESCRIPTION
### Changes being made

Rename "MoH ServiceNow" to "HLTH ServiceNow" as per Brad Allerton

### Context

"MoH" now refers to "Ministry of Housing" and not "Ministry of Health" within BC Gov. Previous references to "MoH" should now be "HLTH"

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)