### PR TITLE
configure idp-restriction for umc

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/user-management/main.tf
@@ -27,6 +27,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "*",
   ]
   authentication_flow_binding_overrides {
+    # browser-idp-restriction flow
     browser_id = "9caca0f9-1c0c-4def-85c6-637d1c8a4d24"
   }
   login_theme = "moh-app-realm-idp-restriction"

--- a/keycloak-dev/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/user-management/main.tf
@@ -26,6 +26,10 @@ resource "keycloak_openid_client" "CLIENT" {
   web_origins = [
     "*",
   ]
+  authentication_flow_binding_overrides {
+    browser_id = "9caca0f9-1c0c-4def-85c6-637d1c8a4d24"
+  }
+  login_theme = "moh-app-realm-idp-restriction"
 }
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
@@ -49,6 +53,14 @@ resource "keycloak_openid_group_membership_protocol_mapper" "Group-Membership" {
   add_to_userinfo = false
   add_to_id_token = false
   full_path       = false
+}
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "idir_aad",
+    "moh_idp",
+  ]
 }
 module "scope-mappings" {
   source    = "../../../../../modules/scope-mappings"


### PR DESCRIPTION
### Changes being made

DEV env: Configuring idp-restriction module for UMC client via terraform.

### Context

Deploying idp-restriction-module to DEV env. Enabling idir_aad and moh_idp identity providers. Will need to update kc_idp_hint for UMC (part of separate task). After the change UMC should show common-logon page instead of redirecting to idp login page.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.