### PR TITLE
add default scopes to UMC dev client

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/user-management/main.tf
@@ -61,6 +61,10 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   default_scopes = [
     "idir_aad",
     "moh_idp",
+    "email",
+    "profile",
+    "roles",
+    "web-origins"
   ]
 }
 module "scope-mappings" {


### PR DESCRIPTION
### Changes being made

Add missing default scopes.

### Context

Previous PR deleted the unspecified default scopes.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 