### PR TITLE
create idp-restriction-module client scopes

### DIFF
--- a/keycloak-dev/realms/moh_applications/clientScopes.tf
+++ b/keycloak-dev/realms/moh_applications/clientScopes.tf
@@ -62,59 +62,59 @@ resource "keycloak_openid_client_scope" "moh_idp_openid_client_scope" {
 resource "keycloak_saml_client_scope" "idir_saml_client_scope" {
   realm_id    = "moh_applications"
   name        = "idir-saml"
-  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with IDIR."
+  description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with IDIR."
 }
 
 resource "keycloak_saml_client_scope" "idir_aad_saml_client_scope" {
   realm_id    = "moh_applications"
   name        = "idir_aad-saml"
-  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with IDIR MFA."
+  description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with IDIR MFA."
 }
 
 resource "keycloak_saml_client_scope" "phsa_saml_client_scope" {
   realm_id    = "moh_applications"
   name        = "phsa-saml"
-  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with Health Authority."
+  description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with Health Authority."
 }
 
 resource "keycloak_saml_client_scope" "phsa_aad_saml_client_scope" {
   realm_id    = "moh_applications"
   name        = "phsa_aad-saml"
-  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with Health Authority MFA."
+  description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with Health Authority MFA."
 }
 
 resource "keycloak_saml_client_scope" "fnha_aad_saml_client_scope" {
   realm_id    = "moh_applications"
   name        = "fnha_aad-saml"
-  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with FNHA MFA."
+  description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with FNHA MFA."
 }
 
 resource "keycloak_saml_client_scope" "bceid_business_saml_client_scope" {
   realm_id    = "moh_applications"
   name        = "bceid_business-saml"
-  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with BceID Business."
+  description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with BceID Business."
 }
 
 resource "keycloak_saml_client_scope" "bcprovider_aad_saml_client_scope" {
   realm_id    = "moh_applications"
   name        = "bcprovider_aad-saml"
-  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with BC Provider."
+  description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with BC Provider."
 }
 
 resource "keycloak_saml_client_scope" "bcsc_saml_client_scope" {
   realm_id    = "moh_applications"
   name        = "bcsc-saml"
-  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with BC Services Card for PIdP."
+  description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with BC Services Card for PIdP."
 }
 
 resource "keycloak_saml_client_scope" "bcsc_mspdirect_saml_client_scope" {
   realm_id    = "moh_applications"
   name        = "bcsc_mspdirect-saml"
-  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with BC Services Card for MSPDirect."
+  description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with BC Services Card for MSPDirect."
 }
 
 resource "keycloak_saml_client_scope" "moh_idp_openid_client_scope" {
   realm_id    = "moh_applications"
   name        = "moh_idp-saml"
-  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with Keycloak."
+  description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with Keycloak."
 }

--- a/keycloak-dev/realms/moh_applications/clientScopes.tf
+++ b/keycloak-dev/realms/moh_applications/clientScopes.tf
@@ -1,0 +1,120 @@
+resource "keycloak_openid_client_scope" "idir_openid_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "idir"
+  description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with IDIR."
+}
+
+resource "keycloak_openid_client_scope" "idir_aad_openid_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "idir_aad"
+  description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with IDIR MFA."
+}
+
+resource "keycloak_openid_client_scope" "phsa_openid_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "phsa"
+  description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with Health Authority."
+}
+
+resource "keycloak_openid_client_scope" "phsa_aad_openid_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "phsa_aad"
+  description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with Health Authority MFA."
+}
+
+resource "keycloak_openid_client_scope" "fnha_aad_openid_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "fnha_aad"
+  description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with FNHA MFA."
+}
+
+resource "keycloak_openid_client_scope" "bceid_business_openid_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "bceid_business"
+  description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with BceID Business."
+}
+
+resource "keycloak_openid_client_scope" "bcprovider_aad_openid_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "bcprovider_aad"
+  description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with BC Provider."
+}
+
+resource "keycloak_openid_client_scope" "bcsc_openid_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "bcsc"
+  description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with BC Services Card for PIdP."
+}
+
+resource "keycloak_openid_client_scope" "bcsc_mspdirect_openid_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "bcsc_mspdirect"
+  description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with BC Services Card for MSPDirect."
+}
+
+
+resource "keycloak_openid_client_scope" "moh_idp_openid_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "moh_idp"
+  description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with Keycloak."
+}
+
+resource "keycloak_saml_client_scope" "idir_saml_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "idir-saml"
+  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with IDIR."
+}
+
+resource "keycloak_saml_client_scope" "idir_aad_saml_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "idir_aad-saml"
+  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with IDIR MFA."
+}
+
+resource "keycloak_saml_client_scope" "phsa_saml_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "phsa-saml"
+  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with Health Authority."
+}
+
+resource "keycloak_saml_client_scope" "phsa_aad_saml_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "phsa_aad-saml"
+  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with Health Authority MFA."
+}
+
+resource "keycloak_saml_client_scope" "fnha_aad_saml_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "fnha_aad-saml"
+  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with FNHA MFA."
+}
+
+resource "keycloak_saml_client_scope" "bceid_business_saml_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "bceid_business-saml"
+  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with BceID Business."
+}
+
+resource "keycloak_saml_client_scope" "bcprovider_aad_saml_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "bcprovider_aad-saml"
+  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with BC Provider."
+}
+
+resource "keycloak_saml_client_scope" "bcsc_saml_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "bcsc-saml"
+  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with BC Services Card for PIdP."
+}
+
+resource "keycloak_saml_client_scope" "bcsc_mspdirect_saml_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "bcsc_mspdirect-saml"
+  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with BC Services Card for MSPDirect."
+}
+
+resource "keycloak_saml_client_scope" "moh_idp_openid_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "moh_idp-saml"
+  description = "Assign this scope to an SAML client using IDP restriction module to allow logging in with Keycloak."
+}


### PR DESCRIPTION
### Changes being made

Creating Client Scopes on DEV that represent IDPs. Those are later assigned to clients to allow use of IDP.

### Context

IDP Restriction module work.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.