### PR TITLE
disable service account option and delete service account roles

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/plr_conf/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_conf/main.tf
@@ -28,7 +28,7 @@ module "payara-client" {
       "name" = "SECONDARY_SOURCE"
     },
   }
-  service_accounts_enabled = true
+  service_accounts_enabled = false
   valid_redirect_uris = [
     "https://plrconf.hlth.gov.bc.ca/plr*",
     "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
@@ -82,22 +82,5 @@ module "service-account-roles" {
   realm_roles = {
     "default-roles-moh_applications" = "default-roles-moh_applications",
   }
-  client_roles = {
-    "USER-MANAGEMENT-SERVICE/view-client-plr_conf" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-client-plr_conf"
-    }
-    "USER-MANAGEMENT-SERVICE/view-clients" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-clients"
-    }
-    "USER-MANAGEMENT-SERVICE/view-users" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-users"
-    }
-    "realm-management/view-users" = {
-      "client_id" = var.realm-management.CLIENT.id,
-      "role_id"   = "view-users"
-    }
-  }
+  client_roles = {}
 }

--- a/keycloak-test/realms/moh_applications/clients/plr_flvr/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_flvr/main.tf
@@ -28,7 +28,7 @@ module "payara-client" {
       "name" = "SECONDARY_SOURCE"
     },
   }
-  service_accounts_enabled = true
+  service_accounts_enabled = false
   valid_redirect_uris = [
     "https://plrflvr.hlth.gov.bc.ca/plr*",
     "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
@@ -81,22 +81,5 @@ module "service-account-roles" {
   realm_roles = {
     "default-roles-moh_applications" = "default-roles-moh_applications",
   }
-  client_roles = {
-    "USER-MANAGEMENT-SERVICE/view-client-plr_flvr" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-client-plr_flvr"
-    }
-    "USER-MANAGEMENT-SERVICE/view-clients" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-clients"
-    }
-    "USER-MANAGEMENT-SERVICE/view-users" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-users"
-    }
-    "realm-management/view-users" = {
-      "client_id" = var.realm-management.CLIENT.id,
-      "role_id"   = "view-users"
-    }
-  }
+  client_roles = {}
 }

--- a/keycloak-test/realms/moh_applications/clients/plr_iat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_iat/main.tf
@@ -28,7 +28,7 @@ module "payara-client" {
       "name" = "SECONDARY_SOURCE"
     },
   }
-  service_accounts_enabled = true
+  service_accounts_enabled = false
   valid_redirect_uris = [
     "https://plriat.hlth.gov.bc.ca/plr*",
     "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
@@ -81,24 +81,7 @@ module "service-account-roles" {
   realm_roles = {
     "default-roles-moh_applications" = "default-roles-moh_applications",
   }
-  client_roles = {
-    "USER-MANAGEMENT-SERVICE/view-client-plr_iat" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-client-plr_iat"
-    }
-    "USER-MANAGEMENT-SERVICE/view-clients" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-clients"
-    }
-    "USER-MANAGEMENT-SERVICE/view-users" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-users"
-    }
-    "realm-management/view-users" = {
-      "client_id" = var.realm-management.CLIENT.id,
-      "role_id"   = "view-users"
-    }
-  }
+  client_roles = {}
 }
 
 resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {

--- a/keycloak-test/realms/moh_applications/clients/plr_rev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_rev/main.tf
@@ -28,7 +28,7 @@ module "payara-client" {
       "name" = "SECONDARY_SOURCE"
     },
   }
-  service_accounts_enabled = true
+  service_accounts_enabled = false
   valid_redirect_uris = [
     "https://plrreview.hlth.gov.bc.ca/plr*",
     "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
@@ -81,24 +81,7 @@ module "service-account-roles" {
   realm_roles = {
     "default-roles-moh_applications" = "default-roles-moh_applications",
   }
-  client_roles = {
-    "USER-MANAGEMENT-SERVICE/view-client-plr_rev" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-client-plr_rev"
-    }
-    "USER-MANAGEMENT-SERVICE/view-clients" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-clients"
-    }
-    "USER-MANAGEMENT-SERVICE/view-users" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-users"
-    }
-    "realm-management/view-users" = {
-      "client_id" = var.realm-management.CLIENT.id,
-      "role_id"   = "view-users"
-    }
-  }
+  client_roles = {}
 }
 
 resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {

--- a/keycloak-test/realms/moh_applications/clients/plr_sit/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_sit/main.tf
@@ -28,7 +28,7 @@ module "payara-client" {
       "name" = "SECONDARY_SOURCE"
     },
   }
-  service_accounts_enabled = true
+  service_accounts_enabled = false
   valid_redirect_uris = [
     "https://plrt.hlth.gov.bc.ca/plr*",
     "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
@@ -82,22 +82,5 @@ module "service-account-roles" {
   realm_roles = {
     "default-roles-moh_applications" = "default-roles-moh_applications",
   }
-  client_roles = {
-    "USER-MANAGEMENT-SERVICE/view-client-plr_sit" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-client-plr_sit"
-    }
-    "USER-MANAGEMENT-SERVICE/view-clients" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-clients"
-    }
-    "USER-MANAGEMENT-SERVICE/view-users" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-users"
-    }
-    "realm-management/view-users" = {
-      "client_id" = var.realm-management.CLIENT.id,
-      "role_id"   = "view-users"
-    }
-  }
+  client_roles = {}
 }

--- a/keycloak-test/realms/moh_applications/clients/plr_stg/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_stg/main.tf
@@ -28,7 +28,7 @@ module "payara-client" {
       "name" = "SECONDARY_SOURCE"
     },
   }
-  service_accounts_enabled = true
+  service_accounts_enabled = false
   valid_redirect_uris = [
     "https://plrstg.hlth.gov.bc.ca/plr*",
     "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
@@ -82,22 +82,5 @@ module "service-account-roles" {
   realm_roles = {
     "default-roles-moh_applications" = "default-roles-moh_applications",
   }
-  client_roles = {
-    "USER-MANAGEMENT-SERVICE/view-client-plr_stg" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-client-plr_stg"
-    }
-    "USER-MANAGEMENT-SERVICE/view-clients" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-clients"
-    }
-    "USER-MANAGEMENT-SERVICE/view-users" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-users"
-    }
-    "realm-management/view-users" = {
-      "client_id" = var.realm-management.CLIENT.id,
-      "role_id"   = "view-users"
-    }
-  }
+  client_roles = {}
 }

--- a/keycloak-test/realms/moh_applications/clients/plr_uat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_uat/main.tf
@@ -28,7 +28,7 @@ module "payara-client" {
       "name" = "SECONDARY_SOURCE"
     },
   }
-  service_accounts_enabled = true
+  service_accounts_enabled = false
   valid_redirect_uris = [
     "https://plrt2.hlth.gov.bc.ca/plr*",
     "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi*",
@@ -81,22 +81,5 @@ module "service-account-roles" {
   realm_roles = {
     "default-roles-moh_applications" = "default-roles-moh_applications",
   }
-  client_roles = {
-    "USER-MANAGEMENT-SERVICE/view-client-plr_uat" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-client-plr_uat"
-    }
-    "USER-MANAGEMENT-SERVICE/view-clients" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-clients"
-    }
-    "USER-MANAGEMENT-SERVICE/view-users" = {
-      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
-      "role_id"   = "view-users"
-    }
-    "realm-management/view-users" = {
-      "client_id" = var.realm-management.CLIENT.id,
-      "role_id"   = "view-users"
-    }
-  }
+  client_roles = {}
 }


### PR DESCRIPTION
### Changes being made

Service account is disabled for PLR_CONF, PLR_FLVR, PLR_IAT, PLR_REV, PLR_SIT, PLR_STG, PLR_UAT. The roles were also deleted from service account roles for these seven clients in test env. They do not exist in dev.

### Context
David S. asked for changes to PLR in dev and test for service account roles.

### Quality Check


- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

