### PR TITLE
remove service account roles module from main.tf

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/plr_conf/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_conf/main.tf
@@ -74,13 +74,3 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-users"           = var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
   }
 }
-module "service-account-roles" {
-  source                  = "../../../../../modules/service-account-roles"
-  realm_id                = module.payara-client.CLIENT.realm_id
-  client_id               = module.payara-client.CLIENT.id
-  service_account_user_id = module.payara-client.CLIENT.service_account_user_id
-  realm_roles = {
-    "default-roles-moh_applications" = "default-roles-moh_applications",
-  }
-  client_roles = {}
-}

--- a/keycloak-test/realms/moh_applications/clients/plr_flvr/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_flvr/main.tf
@@ -73,13 +73,4 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-users"           = var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
   }
 }
-module "service-account-roles" {
-  source                  = "../../../../../modules/service-account-roles"
-  realm_id                = module.payara-client.CLIENT.realm_id
-  client_id               = module.payara-client.CLIENT.id
-  service_account_user_id = module.payara-client.CLIENT.service_account_user_id
-  realm_roles = {
-    "default-roles-moh_applications" = "default-roles-moh_applications",
-  }
-  client_roles = {}
-}
+

--- a/keycloak-test/realms/moh_applications/clients/plr_iat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_iat/main.tf
@@ -73,16 +73,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-users"          = var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
   }
 }
-module "service-account-roles" {
-  source                  = "../../../../../modules/service-account-roles"
-  realm_id                = module.payara-client.CLIENT.realm_id
-  client_id               = module.payara-client.CLIENT.id
-  service_account_user_id = module.payara-client.CLIENT.service_account_user_id
-  realm_roles = {
-    "default-roles-moh_applications" = "default-roles-moh_applications",
-  }
-  client_roles = {}
-}
+
 
 resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
   realm_id        = module.payara-client.CLIENT.realm_id

--- a/keycloak-test/realms/moh_applications/clients/plr_rev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_rev/main.tf
@@ -73,16 +73,6 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-users"          = var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
   }
 }
-module "service-account-roles" {
-  source                  = "../../../../../modules/service-account-roles"
-  realm_id                = module.payara-client.CLIENT.realm_id
-  client_id               = module.payara-client.CLIENT.id
-  service_account_user_id = module.payara-client.CLIENT.service_account_user_id
-  realm_roles = {
-    "default-roles-moh_applications" = "default-roles-moh_applications",
-  }
-  client_roles = {}
-}
 
 resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
   realm_id        = module.payara-client.CLIENT.realm_id

--- a/keycloak-test/realms/moh_applications/clients/plr_sit/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_sit/main.tf
@@ -74,13 +74,3 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-users"          = var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
   }
 }
-module "service-account-roles" {
-  source                  = "../../../../../modules/service-account-roles"
-  realm_id                = module.payara-client.CLIENT.realm_id
-  client_id               = module.payara-client.CLIENT.id
-  service_account_user_id = module.payara-client.CLIENT.service_account_user_id
-  realm_roles = {
-    "default-roles-moh_applications" = "default-roles-moh_applications",
-  }
-  client_roles = {}
-}

--- a/keycloak-test/realms/moh_applications/clients/plr_stg/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_stg/main.tf
@@ -74,13 +74,3 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-users"          = var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
   }
 }
-module "service-account-roles" {
-  source                  = "../../../../../modules/service-account-roles"
-  realm_id                = module.payara-client.CLIENT.realm_id
-  client_id               = module.payara-client.CLIENT.id
-  service_account_user_id = module.payara-client.CLIENT.service_account_user_id
-  realm_roles = {
-    "default-roles-moh_applications" = "default-roles-moh_applications",
-  }
-  client_roles = {}
-}

--- a/keycloak-test/realms/moh_applications/clients/plr_uat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_uat/main.tf
@@ -73,13 +73,3 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-users"          = var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
   }
 }
-module "service-account-roles" {
-  source                  = "../../../../../modules/service-account-roles"
-  realm_id                = module.payara-client.CLIENT.realm_id
-  client_id               = module.payara-client.CLIENT.id
-  service_account_user_id = module.payara-client.CLIENT.service_account_user_id
-  realm_roles = {
-    "default-roles-moh_applications" = "default-roles-moh_applications",
-  }
-  client_roles = {}
-}


### PR DESCRIPTION
### Changes being made

Removed the service account roles module from main.tf for PLR_CONF, PLR_FLVR, PLR_IAT, PLR_REV, PLR_SIT, PLR_STG and PLR_UAT in test env.

### Context

Changes previously made PR#599 caused terraform apply to fail due to "user not found" error. Fix found by David S. to apply.

### Quality Check


- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

