### PR TITLE
add pidp email and phone to SAT-EFORM in test

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/sat-eforms/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sat-eforms/main.tf
@@ -66,6 +66,7 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "common_provider_numbe
   user_attribute      = "common_provider_number"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
+
 resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
   add_to_id_token     = false
   add_to_userinfo     = true
@@ -77,6 +78,7 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
   user_attribute      = "pidp_email"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
+
 resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_phone" {
   add_to_id_token     = false
   add_to_userinfo     = true

--- a/keycloak-test/realms/moh_applications/clients/sat-eforms/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sat-eforms/main.tf
@@ -66,6 +66,28 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "common_provider_numbe
   user_attribute      = "common_provider_number"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
+  add_to_id_token     = false
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name          = "pidpEmail"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "pidp_email"
+  user_attribute      = "pidp_email"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_phone" {
+  add_to_id_token     = false
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name          = "pidpPhone"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "pidp_phone"
+  user_attribute      = "pidp_phone"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
 
 resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id

--- a/keycloak-test/realms/moh_applications/clients/sat-eforms_qa/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sat-eforms_qa/main.tf
@@ -44,3 +44,25 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "bcsc_id" {
   user_attribute  = "bcsc_guid"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
+  add_to_id_token     = false
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name          = "pidpEmail"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "pidp_email"
+  user_attribute      = "pidp_email"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_phone" {
+  add_to_id_token     = false
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name          = "pidpPhone"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "pidp_phone"
+  user_attribute      = "pidp_phone"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}

--- a/keycloak-test/realms/moh_applications/clients/sat-eforms_qa/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sat-eforms_qa/main.tf
@@ -44,6 +44,7 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "bcsc_id" {
   user_attribute  = "bcsc_guid"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
+
 resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
   add_to_id_token     = false
   add_to_userinfo     = true
@@ -55,6 +56,7 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
   user_attribute      = "pidp_email"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
+
 resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_phone" {
   add_to_id_token     = false
   add_to_userinfo     = true


### PR DESCRIPTION
### Changes being made

Added new attributes pidp_email and pidp_phone to SAT-EFORM and SAT-EFORM_QA in test env. Added to userinfo as well as added to access token.

### Context

Requested by client who had SA eforms needing email and phone number added to payload.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

