### PR TITLE
add phone and email attributes to SAT-EFORMS in prod

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/sat-eforms/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/sat-eforms/main.tf
@@ -67,3 +67,27 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "common_provider_numbe
   user_attribute      = "common_provider_number"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_email" {
+  add_to_id_token     = false
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name          = "pidpEmail"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "pidp_email"
+  user_attribute      = "pidp_email"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_phone" {
+  add_to_id_token     = false
+  add_to_userinfo     = true
+  add_to_access_token = true
+  claim_name          = "pidpPhone"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "pidp_phone"
+  user_attribute      = "pidp_phone"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}


### PR DESCRIPTION
### Changes being made

Added pidp_phone and pidp_email to SAT-EFORMS in prod env.

### Context

Changes requested by client to add phone and email attributes to SA eforms to their payload.

### Quality Check
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

