### PR TITLE
Configure idp restriction module for plr

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients.tf
+++ b/keycloak-dev/realms/moh_applications/clients.tf
@@ -106,9 +106,10 @@ module "PIDP-WEBAPP" {
   PIDP-SERVICE = module.PIDP-SERVICE
 }
 module "PLR" {
-  source                  = "./clients/plr"
-  realm-management        = module.realm-management
-  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+  source                       = "./clients/plr"
+  realm-management             = module.realm-management
+  USER-MANAGEMENT-SERVICE      = module.USER-MANAGEMENT-SERVICE
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
 }
 module "PLR-SHOPPERS" {
   source = "./clients/plr-shoppers"
@@ -205,4 +206,7 @@ module "HCIM_VIHA" {
 }
 module "HCIM_VPP" {
   source = "./clients/hcim_vpp"
+}
+locals {
+  browser_idp_restriction_flow = "9caca0f9-1c0c-4def-85c6-637d1c8a4d24"
 }

--- a/keycloak-dev/realms/moh_applications/clients.tf
+++ b/keycloak-dev/realms/moh_applications/clients.tf
@@ -208,5 +208,7 @@ module "HCIM_VPP" {
   source = "./clients/hcim_vpp"
 }
 locals {
+  # ID of the browser-idp-restriction authentication flow in moh_applications DEV.
+  # Used by selected clients, overrides the default browser flow.
   browser_idp_restriction_flow = "9caca0f9-1c0c-4def-85c6-637d1c8a4d24"
 }

--- a/keycloak-dev/realms/moh_applications/clients/plr/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/plr/main.tf
@@ -1,18 +1,15 @@
 module "payara-client" {
-  source                             = "../../../../../modules/payara-client"
-  base_url                           = "https://plrd.hlth.gov.bc.ca/plr"
-  claim_name                         = "plr_role"
-  client_id                          = "PLR"
-  client_name                        = "PLR"
-  client_role_mapper_add_to_id_token = false
-  client_role_mapper_add_to_userinfo = false
-  description                        = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources, and available to authorized consumers, that facilitates the formal exchange of health information."
-  mapper_name                        = "PLR Role"
-  login_theme                        = "moh-app-realm-idp-restriction"
-  # browser-idp-restriction flow
-  authentication_flow_binding_overrides = {
-    browser_id = "9caca0f9-1c0c-4def-85c6-637d1c8a4d24"
-  }
+  source                                          = "../../../../../modules/payara-client"
+  base_url                                        = "https://plrd.hlth.gov.bc.ca/plr"
+  claim_name                                      = "plr_role"
+  client_id                                       = "PLR"
+  client_name                                     = "PLR"
+  client_role_mapper_add_to_id_token              = false
+  client_role_mapper_add_to_userinfo              = false
+  description                                     = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources, and available to authorized consumers, that facilitates the formal exchange of health information."
+  mapper_name                                     = "PLR Role"
+  login_theme                                     = "moh-app-realm-idp-restriction"
+  authentication_flow_binding_override_browser_id = var.browser_idp_restriction_flow
   roles = {
     "DSR_USER" = {
       "name" = "DSR_USER"

--- a/keycloak-dev/realms/moh_applications/clients/plr/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/plr/main.tf
@@ -8,6 +8,9 @@ module "payara-client" {
   client_role_mapper_add_to_userinfo = false
   description                        = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources, and available to authorized consumers, that facilitates the formal exchange of health information."
   mapper_name                        = "PLR Role"
+  login_theme = "moh-app-realm-idp-restriction"
+  # browser-idp-restriction flow
+  browser_flow_id = "9caca0f9-1c0c-4def-85c6-637d1c8a4d24"
   roles = {
     "DSR_USER" = {
       "name" = "DSR_USER"
@@ -46,7 +49,11 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "bceid_business",
+    "idir",
+    "moh_idp",
+    "phsa"
   ]
 }
 resource "keycloak_openid_user_attribute_protocol_mapper" "org_details" {

--- a/keycloak-dev/realms/moh_applications/clients/plr/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/plr/main.tf
@@ -8,9 +8,11 @@ module "payara-client" {
   client_role_mapper_add_to_userinfo = false
   description                        = "The Provider and Location Registry (PLR) is a standards-based repository of core provider data supplied by authorized sources, and available to authorized consumers, that facilitates the formal exchange of health information."
   mapper_name                        = "PLR Role"
-  login_theme = "moh-app-realm-idp-restriction"
+  login_theme                        = "moh-app-realm-idp-restriction"
   # browser-idp-restriction flow
-  browser_flow_id = "9caca0f9-1c0c-4def-85c6-637d1c8a4d24"
+  authentication_flow_binding_overrides = {
+    browser_id = "9caca0f9-1c0c-4def-85c6-637d1c8a4d24"
+  }
   roles = {
     "DSR_USER" = {
       "name" = "DSR_USER"

--- a/keycloak-dev/realms/moh_applications/clients/plr/variables.tf
+++ b/keycloak-dev/realms/moh_applications/clients/plr/variables.tf
@@ -1,2 +1,3 @@
 variable "realm-management" {}
 variable "USER-MANAGEMENT-SERVICE" {}
+variable "browser_idp_restriction_flow" {}

--- a/modules/payara-client/main.tf
+++ b/modules/payara-client/main.tf
@@ -63,9 +63,10 @@ variable "roles" {
   type = map(map(string))
 }
 
-variable "browser_flow_id" {
-  type = string
-  default = null
+variable "authentication_flow_binding_overrides" {
+  type        = map(string)
+  default     = null
+  description = "Optional map for authentication flow binding overrides. Default is null."
 }
 
 
@@ -95,8 +96,11 @@ resource "keycloak_openid_client" "CLIENT" {
   valid_redirect_uris      = var.valid_redirect_uris
   web_origins              = []
   admin_url                = ""
-  authentication_flow_binding_overrides {
-    browser_id = var.browser_flow_id
+  dynamic "authentication_flow_binding_overrides" {
+    for_each = var.authentication_flow_binding_overrides != null ? [1] : []
+    content {
+      browser_id = lookup(var.authentication_flow_binding_overrides, "browser_id", null)
+    }
   }
 }
 

--- a/modules/payara-client/main.tf
+++ b/modules/payara-client/main.tf
@@ -63,8 +63,8 @@ variable "roles" {
   type = map(map(string))
 }
 
-variable "authentication_flow_binding_overrides" {
-  type        = map(string)
+variable "authentication_flow_binding_override_browser_id" {
+  type        = string
   default     = null
   description = "Authentication flow binding overrides - used by IDP restriction module."
 }
@@ -97,9 +97,9 @@ resource "keycloak_openid_client" "CLIENT" {
   web_origins              = []
   admin_url                = ""
   dynamic "authentication_flow_binding_overrides" {
-    for_each = var.authentication_flow_binding_overrides != null ? [1] : []
+    for_each = var.authentication_flow_binding_override_browser_id != null ? [1] : []
     content {
-      browser_id = lookup(var.authentication_flow_binding_overrides, "browser_id", null)
+      browser_id = var.authentication_flow_binding_override_browser_id
     }
   }
 }

--- a/modules/payara-client/main.tf
+++ b/modules/payara-client/main.tf
@@ -66,7 +66,7 @@ variable "roles" {
 variable "authentication_flow_binding_overrides" {
   type        = map(string)
   default     = null
-  description = "Optional map for authentication flow binding overrides. Default is null."
+  description = "Authentication flow binding overrides - used by IDP restriction module."
 }
 
 

--- a/modules/payara-client/main.tf
+++ b/modules/payara-client/main.tf
@@ -63,6 +63,11 @@ variable "roles" {
   type = map(map(string))
 }
 
+variable "browser_flow_id" {
+  type = string
+  default = null
+}
+
 
 resource "keycloak_openid_client" "CLIENT" {
   access_type = "CONFIDENTIAL"
@@ -90,6 +95,9 @@ resource "keycloak_openid_client" "CLIENT" {
   valid_redirect_uris      = var.valid_redirect_uris
   web_origins              = []
   admin_url                = ""
+  authentication_flow_binding_overrides {
+    browser_id = var.browser_flow_id
+  }
 }
 
 resource "keycloak_role" "ROLES" {


### PR DESCRIPTION
### Changes being made

Override browser flow and theme for PLR client on DEV so that it uses the IDP restriction module.
Update payara-client module to allow overriding authentication(browser) flows.

### Context

IDP Restriction module work.
AuthenticationFlowBindingOverrides is an object, so unlike with primitive types a simple conditional expression cannot be used. Empty object would be created for each payara client that doesn't override authentication flow.
Instead, the solution uses `dynamic block` to conditionally assign this resource property. This ensures that only clients with `authentication_flow_binding_overrides` variable will undergo configuration change,

If `var.authentication_flow_binding_overrides` is not null, [1] triggers the dynamic block to create a single authentication_flow_binding_overrides block. [1] represents a list with single element.
If `var.authentication_flow_binding_overrides` is null, the empty list [] ensures that the dynamic block is not rendered at all.

I wanted to make configuration look the same, regardless if it's client from payara or a plain oidc client. That's why `variable "authentication_flow_binding_overrides"` is a map/object, instead of primitive type (for example just `browser_id` could be passed as a variable)

https://developer.hashicorp.com/terraform/language/v1.3.x/expressions/dynamic-blocks
https://developer.hashicorp.com/terraform/language/v1.3.x/expressions/conditionals

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.