### PR TITLE
update manage-users permissions

### DIFF
--- a/keycloak-dev/realms/moh_applications/realm-roles/manage-users/main.tf
+++ b/keycloak-dev/realms/moh_applications/realm-roles/manage-users/main.tf
@@ -1,5 +1,6 @@
 resource "keycloak_role" "REALM_ROLE" {
   composite_roles = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["bulk-removal"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-all-groups"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-org"].id,
@@ -27,7 +28,7 @@ resource "keycloak_role" "REALM_ROLE" {
     var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id,
     var.USER-MANAGEMENT.ROLES["user-management-admin"].id,
   ]
-  description = "Provides the roles required to manage users using the USER-MANAGEMENT application including roles for all applications.  In DEV this role is provided to the Developer and Midtier teams."
+  description = "Provides the roles required to manage users using the USER-MANAGEMENT application including roles for all applications.  In DEV this role is provided to the Developer and AM teams."
   name        = "Manage Users"
   realm_id    = "moh_applications"
 }


### PR DESCRIPTION
### Changes being made

Add bulk-removal role to Manage-Users realm role.

### Context

On Keycloak DEV env, Manage-users is assigned to the am team and cgi dev team.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 
- [ ] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. 