### PR TITLE
promote phlat to production

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients.tf
+++ b/keycloak-prod/realms/moh_applications/clients.tf
@@ -168,6 +168,13 @@ module "ORGANIZATIONS-API" {
 module "PANORAMA" {
   source = "./clients/panorama"
 }
+module "PHLAT-SERVICE" {
+  source = "./clients/phlat-service"
+  PLR    = module.PLR
+}
+module "PHLAT-WEB" {
+  source = "./clients/phlat-web"
+}
 module "PHO-RSC" {
   source         = "./clients/pho-rsc"
   PHO-RSC-GROUPS = module.PHO-RSC-GROUPS

--- a/keycloak-prod/realms/moh_applications/clients/phlat-service/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/phlat-service/main.tf
@@ -1,0 +1,86 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "PHLAT-SERVICE"
+  consent_required                    = false
+  description                         = "PLR Health Service Delivery Site Data Load Assistant Tool - Service Account Used for PLR CONF communication"
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "PHLAT-SERVICE"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = true
+  standard_flow_enabled               = false
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+resource "keycloak_openid_hardcoded_claim_protocol_mapper" "orgId" {
+  add_to_access_token = true
+  add_to_id_token     = true
+  add_to_userinfo     = true
+  claim_name          = "orgId"
+  claim_value         = "00002855"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "orgId"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+}
+resource "keycloak_openid_user_session_note_protocol_mapper" "Client-Host" {
+  add_to_id_token  = true
+  claim_name       = "clientHost"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "Client Host"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "clientHost"
+}
+resource "keycloak_openid_user_session_note_protocol_mapper" "Client-ID" {
+  add_to_id_token  = true
+  claim_name       = "clientId"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "Client ID"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "clientId"
+}
+resource "keycloak_openid_user_session_note_protocol_mapper" "Client-IP-Address" {
+  add_to_id_token  = true
+  claim_name       = "clientAddress"
+  claim_value_type = "String"
+  client_id        = keycloak_openid_client.CLIENT.id
+  name             = "Client IP Address"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  session_note     = "clientAddress"
+}
+module "service-account-roles" {
+  source                  = "../../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {
+    "PLR/REG_ADMIN" = {
+      "client_id" = var.PLR.CLIENT.id,
+      "role_id"   = "REG_ADMIN"
+    }
+  }
+}
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "PLR/REG_ADMIN" = var.PLR.ROLES["REG_ADMIN"].id
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/phlat-service/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/phlat-service/main.tf
@@ -6,7 +6,7 @@ resource "keycloak_openid_client" "CLIENT" {
   client_authenticator_type           = "client-secret"
   client_id                           = "PHLAT-SERVICE"
   consent_required                    = false
-  description                         = "PLR Health Service Delivery Site Data Load Assistant Tool - Service Account Used for PLR CONF communication"
+  description                         = "PLR Health Service Delivery Site Data Load Assistant Tool - Service Account Used for PLR communication"
   direct_access_grants_enabled        = false
   enabled                             = true
   frontchannel_logout_enabled         = false

--- a/keycloak-prod/realms/moh_applications/clients/phlat-service/outputs.tf
+++ b/keycloak-prod/realms/moh_applications/clients/phlat-service/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-prod/realms/moh_applications/clients/phlat-service/variables.tf
+++ b/keycloak-prod/realms/moh_applications/clients/phlat-service/variables.tf
@@ -1,0 +1,1 @@
+variable "PLR" {}

--- a/keycloak-prod/realms/moh_applications/clients/phlat-service/versions.tf
+++ b/keycloak-prod/realms/moh_applications/clients/phlat-service/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/phlat-web/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/phlat-web/main.tf
@@ -1,0 +1,54 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "PUBLIC"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "PHLAT-WEB"
+  consent_required                    = false
+  description                         = "PLR Health Service Delivery Site Data Load Assistant Tool - Web Application"
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "PHLAT"
+  pkce_code_challenge_method          = "S256"
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+    "https://phlat.hlth.gov.bc.ca/*",
+  ]
+  web_origins = [
+    "+",
+  ]
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "Client-Role-Mapper-PHLAT" {
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "PHLAT-WEB"
+  name                        = "PHLAT Role Mapper"
+  claim_name                  = "roles"
+  multivalued                 = true
+  claim_value_type            = "String"
+  add_to_id_token             = true
+  add_to_access_token         = true
+  add_to_userinfo             = true
+}
+
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "REG_USER" : {
+      "name" : "REG_USER",
+    },
+    "REG_ADMIN" : {
+      "name" : "REG_ADMIN",
+    },
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/phlat-web/outputs.tf
+++ b/keycloak-prod/realms/moh_applications/clients/phlat-web/outputs.tf
@@ -1,0 +1,6 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}
+output "ROLES" {
+  value = module.client-roles.ROLES
+}

--- a/keycloak-prod/realms/moh_applications/clients/phlat-web/versions.tf
+++ b/keycloak-prod/realms/moh_applications/clients/phlat-web/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/user-management-service/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/user-management-service/main.tf
@@ -109,6 +109,9 @@ module "client-roles" {
     "view-client-mspdirect-service" = {
       "name" = "view-client-mspdirect-service"
     },
+    "view-client-phlat-web" = {
+      "name" = "view-client-phlat-web"
+    },
     "view-client-pho-rsc" = {
       "name" = "view-client-pho-rsc"
     },

--- a/keycloak-prod/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/user-management/main.tf
@@ -77,6 +77,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-client-maid"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-maid"].id,
     "USER-MANAGEMENT-SERVICE/view-client-miwt"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt"].id,
     "USER-MANAGEMENT-SERVICE/view-client-mspdirect-service"         = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-mspdirect-service"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-phlat-web"                 = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-phlat-web"].id,
     "USER-MANAGEMENT-SERVICE/view-client-pho-rsc"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pho-rsc"].id,
     "USER-MANAGEMENT-SERVICE/view-client-pho-rsc-groups"            = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pho-rsc-groups"].id,
     "USER-MANAGEMENT-SERVICE/view-client-pidp-service"              = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pidp-service"].id,

--- a/keycloak-prod/realms/moh_applications/groups.tf
+++ b/keycloak-prod/realms/moh_applications/groups.tf
@@ -63,6 +63,11 @@ module "PAS-MANAGEMENT" {
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
 }
 
+module "PHLAT-MANAGEMENT" {
+  source                  = "./groups/phlat-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
 module "PHO-RSC-MANAGEMENT" {
   source                  = "./groups/pho-rsc-management"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE

--- a/keycloak-prod/realms/moh_applications/groups/phlat-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/groups/phlat-management/main.tf
@@ -1,0 +1,19 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "PHLAT Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-phlat-web"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-prod/realms/moh_applications/groups/phlat-management/output.tf
+++ b/keycloak-prod/realms/moh_applications/groups/phlat-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-prod/realms/moh_applications/groups/phlat-management/variables.tf
+++ b/keycloak-prod/realms/moh_applications/groups/phlat-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-prod/realms/moh_applications/groups/phlat-management/versions.tf
+++ b/keycloak-prod/realms/moh_applications/groups/phlat-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}

--- a/keycloak-prod/realms/moh_applications/realm-roles/manage-users/main.tf
+++ b/keycloak-prod/realms/moh_applications/realm-roles/manage-users/main.tf
@@ -25,6 +25,7 @@ resource "keycloak_role" "REALM_ROLE" {
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-maid"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-mspdirect-service"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-phlat-web"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pho-rsc"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pidp-service"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-plr"].id,


### PR DESCRIPTION
### Changes being made

Promoting PHLAT clients to Production. Changes include:

- Create PHLAT-WEB client. Public client with default access token lifespan.
- Create PHLAT-SERVICE client. Service account used to communicate with PLR.
- Create PHLAT-MANAGEMENT group so users' access can be managed through UMC.
- Update UMC and UMS config to include view-client-phlat-web role
- Update ManageUsers realm role.

### Context

Client onboarding PHLAT is moving to Production.

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. 
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.
- [x] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [x] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply.
