### PR TITLE
create edrd-management group

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/user-management-service/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/user-management-service/main.tf
@@ -58,6 +58,9 @@ module "client-roles" {
     "view-client-eacl" = {
       "name" = "view-client-eacl"
     },
+    "view-client-edrd" = {
+      "name" = "view-client-edrd"
+    },
     "view-client-emcod" = {
       "name" = "view-client-emcod"
     },

--- a/keycloak-prod/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/user-management/main.tf
@@ -62,6 +62,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-client-bcer-cp"                   = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
     "USER-MANAGEMENT-SERVICE/view-client-dmft-webappp"              = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-dmft-webapp"].id,
     "USER-MANAGEMENT-SERVICE/view-client-eacl"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-eacl"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-edrd"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-edrd"].id,
     "USER-MANAGEMENT-SERVICE/view-client-emcod"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-emcod"].id,
     "USER-MANAGEMENT-SERVICE/view-client-fmdb"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-fmdb"].id,
     "USER-MANAGEMENT-SERVICE/view-client-gis"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-gis"].id,

--- a/keycloak-prod/realms/moh_applications/groups.tf
+++ b/keycloak-prod/realms/moh_applications/groups.tf
@@ -23,6 +23,11 @@ module "CGI-REGISTRIES-ADMIN" {
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
 }
 
+module "EDRD-MANAGEMENT" {
+  source                  = "./groups/edrd-management"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
+
 module "EMCOD-ACCESS-TEAM" {
   source                  = "./groups/emcod-access-team"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE

--- a/keycloak-prod/realms/moh_applications/groups/edrd-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/groups/edrd-management/main.tf
@@ -1,0 +1,19 @@
+resource "keycloak_group" "GROUP" {
+  realm_id = "moh_applications"
+  name     = "EDRD Management"
+}
+
+resource "keycloak_group_roles" "GROUP_ROLES" {
+  realm_id = keycloak_group.GROUP.realm_id
+  group_id = keycloak_group.GROUP.id
+
+  role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-edrd"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-users"].id
+  ]
+}

--- a/keycloak-prod/realms/moh_applications/groups/edrd-management/output.tf
+++ b/keycloak-prod/realms/moh_applications/groups/edrd-management/output.tf
@@ -1,0 +1,3 @@
+output "GROUP" {
+  value = keycloak_group.GROUP
+}

--- a/keycloak-prod/realms/moh_applications/groups/edrd-management/variables.tf
+++ b/keycloak-prod/realms/moh_applications/groups/edrd-management/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-prod/realms/moh_applications/groups/edrd-management/versions.tf
+++ b/keycloak-prod/realms/moh_applications/groups/edrd-management/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "= 3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Adding EDRD-Management group on Prod, so that roles can be assigned through UMC.

### Context

EDRD client onboarding. This group may be temporary - depending on who will be admin team once they fully cut over.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.