### PR TITLE
create bulk-upload clients

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients.tf
+++ b/keycloak-dev/realms/moh_applications/clients.tf
@@ -10,6 +10,10 @@ module "BCER-CP" {
 module "BCHCIM" {
   source = "./clients/bchcim"
 }
+module "BULK-USER-UPLOAD" {
+  source           = "./clients/bulk-user-upload"
+  realm-management = module.realm-management
+}
 module "CONNECT" {
   source = "./clients/connect"
 }

--- a/keycloak-dev/realms/moh_applications/clients/bulk-user-upload/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/bulk-user-upload/main.tf
@@ -12,7 +12,7 @@ resource "keycloak_openid_client" "CLIENT" {
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
   implicit_flow_enabled               = false
-  name                                = ""
+  name                                = "BULK-USER-UPLOAD"
   pkce_code_challenge_method          = ""
   realm_id                            = "moh_applications"
   service_accounts_enabled            = true

--- a/keycloak-dev/realms/moh_applications/clients/bulk-user-upload/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/bulk-user-upload/main.tf
@@ -1,0 +1,68 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = "1800"
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = false
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "BULK-USER-UPLOAD"
+  consent_required                    = false
+  description                         = "Service account used for bulk user upload and role assignment."
+  direct_access_grants_enabled        = false
+  enabled                             = false
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = ""
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = true
+  standard_flow_enabled               = false
+  use_refresh_tokens                  = false
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "realm-management/manage-users"  = var.realm-management.ROLES["manage-users"].id,
+    "realm-management/query-clients" = var.realm-management.ROLES["query-clients"].id,
+    "realm-management/query-users"   = var.realm-management.ROLES["query-users"].id,
+    "realm-management/view-clients"  = var.realm-management.ROLES["view-clients"].id,
+    "realm-management/view-users"    = var.realm-management.ROLES["view-users"].id,
+  }
+}
+module "service-account-roles" {
+  source                  = "../../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {
+    "realm-management/manage-users" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "manage-users"
+    }
+    "realm-management/query-clients" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "query-clients"
+    }
+    "realm-management/query-users" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "query-users"
+    }
+    "realm-management/view-clients" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "view-clients"
+    }
+    "realm-management/view-users" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "view-users"
+    }
+  }
+}

--- a/keycloak-dev/realms/moh_applications/clients/bulk-user-upload/outputs.tf
+++ b/keycloak-dev/realms/moh_applications/clients/bulk-user-upload/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-dev/realms/moh_applications/clients/bulk-user-upload/variables.tf
+++ b/keycloak-dev/realms/moh_applications/clients/bulk-user-upload/variables.tf
@@ -1,0 +1,1 @@
+variable "realm-management" {}

--- a/keycloak-dev/realms/moh_applications/clients/bulk-user-upload/versions.tf
+++ b/keycloak-dev/realms/moh_applications/clients/bulk-user-upload/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients.tf
+++ b/keycloak-prod/realms/moh_applications/clients.tf
@@ -13,6 +13,10 @@ module "BCER-CP" {
 module "BCHCIM" {
   source = "./clients/bchcim"
 }
+module "BULK-USER-UPLOAD" {
+  source           = "./clients/bulk-user-upload"
+  realm-management = module.realm-management
+}
 module "CMDB" {
   source = "./clients/cmdb"
 }

--- a/keycloak-prod/realms/moh_applications/clients/bulk-user-upload/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/bulk-user-upload/main.tf
@@ -12,7 +12,7 @@ resource "keycloak_openid_client" "CLIENT" {
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
   implicit_flow_enabled               = false
-  name                                = ""
+  name                                = "BULK-USER-UPLOAD"
   pkce_code_challenge_method          = ""
   realm_id                            = "moh_applications"
   service_accounts_enabled            = true

--- a/keycloak-prod/realms/moh_applications/clients/bulk-user-upload/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/bulk-user-upload/main.tf
@@ -1,0 +1,68 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = "1800"
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = false
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "BULK-USER-UPLOAD"
+  consent_required                    = false
+  description                         = "Service account used for bulk user upload and role assignment."
+  direct_access_grants_enabled        = false
+  enabled                             = false
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = ""
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = true
+  standard_flow_enabled               = false
+  use_refresh_tokens                  = false
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "realm-management/manage-users"  = var.realm-management.ROLES["manage-users"].id,
+    "realm-management/query-clients" = var.realm-management.ROLES["query-clients"].id,
+    "realm-management/query-users"   = var.realm-management.ROLES["query-users"].id,
+    "realm-management/view-clients"  = var.realm-management.ROLES["view-clients"].id,
+    "realm-management/view-users"    = var.realm-management.ROLES["view-users"].id,
+  }
+}
+module "service-account-roles" {
+  source                  = "../../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {
+    "realm-management/manage-users" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "manage-users"
+    }
+    "realm-management/query-clients" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "query-clients"
+    }
+    "realm-management/query-users" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "query-users"
+    }
+    "realm-management/view-clients" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "view-clients"
+    }
+    "realm-management/view-users" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "view-users"
+    }
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/bulk-user-upload/outputs.tf
+++ b/keycloak-prod/realms/moh_applications/clients/bulk-user-upload/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-prod/realms/moh_applications/clients/bulk-user-upload/variables.tf
+++ b/keycloak-prod/realms/moh_applications/clients/bulk-user-upload/variables.tf
@@ -1,0 +1,1 @@
+variable "realm-management" {}

--- a/keycloak-prod/realms/moh_applications/clients/bulk-user-upload/versions.tf
+++ b/keycloak-prod/realms/moh_applications/clients/bulk-user-upload/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -13,6 +13,10 @@ module "BCER-CP" {
 module "BCHCIM" {
   source = "./clients/bchcim"
 }
+module "BULK-USER-UPLOAD" {
+  source           = "./clients/bulk-user-upload"
+  realm-management = module.realm-management
+}
 module "CONNECT" {
   source = "./clients/connect"
 }

--- a/keycloak-test/realms/moh_applications/clients/bulk-user-upload/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/bulk-user-upload/main.tf
@@ -12,7 +12,7 @@ resource "keycloak_openid_client" "CLIENT" {
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
   implicit_flow_enabled               = false
-  name                                = ""
+  name                                = "BULK-USER-UPLOAD"
   pkce_code_challenge_method          = ""
   realm_id                            = "moh_applications"
   service_accounts_enabled            = true

--- a/keycloak-test/realms/moh_applications/clients/bulk-user-upload/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/bulk-user-upload/main.tf
@@ -1,0 +1,68 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = "1800"
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = false
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "BULK-USER-UPLOAD"
+  consent_required                    = false
+  description                         = "Service account used for bulk user upload and role assignment."
+  direct_access_grants_enabled        = false
+  enabled                             = false
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = ""
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = true
+  standard_flow_enabled               = false
+  use_refresh_tokens                  = false
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "realm-management/manage-users"  = var.realm-management.ROLES["manage-users"].id,
+    "realm-management/query-clients" = var.realm-management.ROLES["query-clients"].id,
+    "realm-management/query-users"   = var.realm-management.ROLES["query-users"].id,
+    "realm-management/view-clients"  = var.realm-management.ROLES["view-clients"].id,
+    "realm-management/view-users"    = var.realm-management.ROLES["view-users"].id,
+  }
+}
+module "service-account-roles" {
+  source                  = "../../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {
+    "realm-management/manage-users" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "manage-users"
+    }
+    "realm-management/query-clients" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "query-clients"
+    }
+    "realm-management/query-users" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "query-users"
+    }
+    "realm-management/view-clients" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "view-clients"
+    }
+    "realm-management/view-users" = {
+      "client_id" = var.realm-management.CLIENT.id,
+      "role_id"   = "view-users"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/bulk-user-upload/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/bulk-user-upload/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/bulk-user-upload/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/bulk-user-upload/variables.tf
@@ -1,0 +1,1 @@
+variable "realm-management" {}

--- a/keycloak-test/realms/moh_applications/clients/bulk-user-upload/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/bulk-user-upload/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Creating bulk-upload clients on dev/test/prod. The clients are disabled by default.

### Context

Clients (their service accounts) are used to perform bulk user upload and role assignment to Keycloak. Previously, the script was using a plain user to execute the script via admin-cli. 

Before applying, the client on dev needs to be deleted. 

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided.
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.