### PR TITLE
Remove manage-own-groups from multiple CGI Groups.

### DIFF
--- a/keycloak-prod/realms/moh_applications/groups/cgi-registries-admin/main.tf
+++ b/keycloak-prod/realms/moh_applications/groups/cgi-registries-admin/main.tf
@@ -9,7 +9,6 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
 
   role_ids = [
     var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_hs1"].id,

--- a/keycloak-prod/realms/moh_applications/groups/cgi-salesforce/main.tf
+++ b/keycloak-prod/realms/moh_applications/groups/cgi-salesforce/main.tf
@@ -9,7 +9,6 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
 
   role_ids = [
     var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-alr"].id,

--- a/keycloak-test/realms/moh_applications/groups/cgi-registries-admin/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-registries-admin/main.tf
@@ -9,7 +9,6 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
 
   role_ids = [
     var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hcimweb_huat"].id,

--- a/keycloak-test/realms/moh_applications/groups/cgi-salesforce/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/cgi-salesforce/main.tf
@@ -9,7 +9,6 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
 
   role_ids = [
     var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
-    var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-alr"].id,


### PR DESCRIPTION
### Changes being made

Remove manage-own-groups from multiple CGI Groups.

### Context

Group management for CGI groups must be managed by access requests on JIRA with client approval.

### Quality Check
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]