### PR TITLE
Add mapper to override preferred_username with legacy PHSA username f…

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/bcer-cp/main.tf
@@ -42,3 +42,18 @@ module "client-roles" {
     },
   }
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/connect/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/connect/main.tf
@@ -70,3 +70,18 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/ehpr/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/ehpr/main.tf
@@ -26,4 +26,18 @@ resource "keycloak_openid_client" "CLIENT" {
   web_origins = [
     "+"
   ]
+}resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
 }

--- a/keycloak-prod/realms/moh_applications/clients/ehpr/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/ehpr/main.tf
@@ -26,7 +26,9 @@ resource "keycloak_openid_client" "CLIENT" {
   web_origins = [
     "+"
   ]
-}resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+}
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
   client_id       = keycloak_openid_client.CLIENT.id
   name            = "preferred_username"

--- a/keycloak-prod/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/forms/main.tf
@@ -71,3 +71,18 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/gis/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/gis/main.tf
@@ -22,3 +22,19 @@ module "payara-client" {
     "https://gis.ynr9ed-prod.nimbus.cloud.gov.bc.ca/gis/*"
   ]
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/hamis/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hamis/main.tf
@@ -97,3 +97,19 @@ module "service-account-roles" {
     }
   }
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/hcap-fe/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hcap-fe/main.tf
@@ -85,3 +85,18 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "user_id" {
   user_attribute  = "bcsc_guid"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/hcimweb/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hcimweb/main.tf
@@ -70,3 +70,19 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/hoopc/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hoopc/main.tf
@@ -35,3 +35,18 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = keycloak_openid_client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/hscis/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hscis/main.tf
@@ -80,3 +80,19 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
@@ -150,7 +150,9 @@ module "client-roles" {
       "name" = "HSPP_ReportSection_DART"
     },
   }
-}resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+}
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
   client_id       = keycloak_openid_client.CLIENT.id
   name            = "preferred_username"

--- a/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
@@ -150,4 +150,18 @@ module "client-roles" {
       "name" = "HSPP_ReportSection_DART"
     },
   }
+}resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
 }

--- a/keycloak-prod/realms/moh_applications/clients/icy/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/icy/main.tf
@@ -420,3 +420,18 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   name                        = "client roles"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/ien/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/ien/main.tf
@@ -44,3 +44,18 @@ module "client-roles" {
     },
   }
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/ldap-acc-trans/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/ldap-acc-trans/main.tf
@@ -40,3 +40,18 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = keycloak_openid_client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/metaspace/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/metaspace/main.tf
@@ -99,3 +99,18 @@ resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
     "phone"
   ]
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/miwt/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/miwt/main.tf
@@ -50,3 +50,19 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/moh-servicenow/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/moh-servicenow/main.tf
@@ -44,3 +44,18 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider"
   realm_id         = keycloak_openid_client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/mspdirect-web/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/mspdirect-web/main.tf
@@ -59,3 +59,18 @@ module "scope-mappings" {
     "MSPDIRECT-SERVICE/VISARESIDENT"       = var.MSPDIRECT-SERVICE.ROLES["VISARESIDENT"].id,
   }
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/pho-rsc/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/pho-rsc/main.tf
@@ -88,4 +88,18 @@ module "scope-mappings" {
     "PHO-RSC-GROUPS/hsiar_wfa"  = var.PHO-RSC-GROUPS.ROLES["hsiar_wfa"].id,
     "PHO-RSC-GROUPS/hsiar_phar" = var.PHO-RSC-GROUPS.ROLES["hsiar_phar"].id,
   }
+}resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
 }

--- a/keycloak-prod/realms/moh_applications/clients/pho-rsc/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/pho-rsc/main.tf
@@ -88,7 +88,9 @@ module "scope-mappings" {
     "PHO-RSC-GROUPS/hsiar_wfa"  = var.PHO-RSC-GROUPS.ROLES["hsiar_wfa"].id,
     "PHO-RSC-GROUPS/hsiar_phar" = var.PHO-RSC-GROUPS.ROLES["hsiar_phar"].id,
   }
-}resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+}
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
   client_id       = keycloak_openid_client.CLIENT.id
   name            = "preferred_username"

--- a/keycloak-prod/realms/moh_applications/clients/pidp-webapp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/pidp-webapp/main.tf
@@ -62,3 +62,18 @@ module "scope-mappings" {
     "account/view-profile"           = var.account.ROLES["view-profile"].id,
   }
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/plr/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/plr/main.tf
@@ -54,3 +54,19 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
@@ -223,3 +223,18 @@ module "scope-mappings" {
     "LICENCE-STATUS/RNP"          = var.LICENCE-STATUS.ROLES["RNP"].id
   }
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/prime-application/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/prime-application/main.tf
@@ -146,3 +146,18 @@ module "scope-mappings" {
     "account/view-profile"   = var.account.ROLES["view-profile"].id,
   }
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/prime-webapp-enrollment/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/prime-webapp-enrollment/main.tf
@@ -49,7 +49,9 @@ module "scope-mappings" {
     "account/manage-account" = var.account.ROLES["manage-account"].id,
     "account/view-profile"   = var.account.ROLES["view-profile"].id,
   }
-}resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+}
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
   client_id       = keycloak_openid_client.CLIENT.id
   name            = "preferred_username"

--- a/keycloak-prod/realms/moh_applications/clients/prime-webapp-enrollment/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/prime-webapp-enrollment/main.tf
@@ -49,4 +49,18 @@ module "scope-mappings" {
     "account/manage-account" = var.account.ROLES["manage-account"].id,
     "account/view-profile"   = var.account.ROLES["view-profile"].id,
   }
+}resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
 }

--- a/keycloak-prod/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/prp-web/main.tf
@@ -95,3 +95,18 @@ module "scope-mappings" {
     "LICENCE-STATUS/RNP"                  = var.LICENCE-STATUS.ROLES["RNP"].id
   }
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/sat-eforms/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/sat-eforms/main.tf
@@ -90,7 +90,9 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_phone" {
   name                = "pidp_phone"
   user_attribute      = "pidp_phone"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
-}resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+}
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
   client_id       = keycloak_openid_client.CLIENT.id
   name            = "preferred_username"

--- a/keycloak-prod/realms/moh_applications/clients/sat-eforms/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/sat-eforms/main.tf
@@ -90,4 +90,18 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "pidp_phone" {
   name                = "pidp_phone"
   user_attribute      = "pidp_phone"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
+}resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
 }

--- a/keycloak-prod/realms/moh_applications/clients/sfds/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/sfds/main.tf
@@ -77,3 +77,19 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/swt/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/swt/main.tf
@@ -25,3 +25,19 @@ module "payara-client" {
     "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi*",
   ]
 }
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = module.payara-client.CLIENT.realm_id
+  client_id       = module.payara-client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "false",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/swt/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/swt/main.tf
@@ -25,19 +25,3 @@ module "payara-client" {
     "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi*",
   ]
 }
-
-resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
-  realm_id        = module.payara-client.CLIENT.realm_id
-  client_id       = module.payara-client.CLIENT.id
-  name            = "preferred_username"
-  protocol        = "openid-connect"
-  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
-  config = {
-    "userinfo.token.claim" : "false",
-    "user.attribute" : "phsa_windowsaccountname",
-    "id.token.claim" : "true",
-    "access.token.claim" : "true",
-    "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
-  }
-}

--- a/keycloak-prod/realms/moh_applications/clients/tbcm/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/tbcm/main.tf
@@ -49,7 +49,9 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   multivalued                 = true
   name                        = "client roles"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id
-}resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+}
+
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
   client_id       = keycloak_openid_client.CLIENT.id
   name            = "preferred_username"

--- a/keycloak-prod/realms/moh_applications/clients/tbcm/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/tbcm/main.tf
@@ -49,4 +49,18 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   multivalued                 = true
   name                        = "client roles"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
 }

--- a/keycloak-prod/realms/moh_applications/clients/webcaps/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/webcaps/main.tf
@@ -105,3 +105,18 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   realm_id         = keycloak_openid_client.CLIENT.realm_id
   session_note     = "identity_provider"
 }
+resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "preferred_username"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
+  config = {
+    "userinfo.token.claim" : "true",
+    "user.attribute" : "phsa_windowsaccountname",
+    "id.token.claim" : "true",
+    "access.token.claim" : "true",
+    "claim.name" : "preferred_username",
+    "jsonType.label" : "String"
+  }
+}


### PR DESCRIPTION
### Changes being made

Add mapper to override preferred_username with legacy PHSA username for all PROD clients that use PHSA login.

### Context

BCMOHAM/RFC-20240830-02-BCMOHAD-25066-PROD-KEYCLOAK-Change_PHSA_Username_Format

### Quality Check
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]