### PR TITLE
adding two attribute mappers for siteminder_user_guid to emaccs

### DIFF
--- a/keycloak-test/realms/moh_citizen/clients/emaccs/main.tf
+++ b/keycloak-test/realms/moh_citizen/clients/emaccs/main.tf
@@ -26,3 +26,23 @@ resource "keycloak_openid_client" "CLIENT" {
   web_origins = [
   ]
 }
+resource "keycloak_openid_user_attribute_protocol_mapper" "idir_user_guid" {
+  add_to_access_token = true
+  add_to_userinfo = var.client_role_mapper_add_to_id_token
+  add_to_userinfo = var.client_role_mapper_add_to_userinfo
+  claim_name      = "idir_user_guid"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "idir_user_guid"
+  user_attribute  = "siteminder_user_guid"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+resource "keycloak_openid_user_attribute_protocol_mapper" "bceid_user_guid" {
+  add_to_access_token = true
+  add_to_userinfo = var.client_role_mapper_add_to_id_token
+  add_to_userinfo = var.client_role_mapper_add_to_userinfo
+  claim_name      = "bceid_user_guid"
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "bceid_user_guid"
+  user_attribute  = "siteminder_user_guid"
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+}


### PR DESCRIPTION
### Changes being made

Adding two attribute mappers to EMACCS in test. Both map to user attribute siteminder_user_guid.

### Context

Change requested by Adam and David.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
