### PR TITLE
add prp roles and configure idp restriction module

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients.tf
+++ b/keycloak-dev/realms/moh_applications/clients.tf
@@ -162,6 +162,7 @@ module "UMS-INTEGRATION-TESTS" {
 module "USER-MANAGEMENT" {
   source                  = "./clients/user-management"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
 }
 module "HCIM_BCMI" {
   source = "./clients/hcim_bcmi"

--- a/keycloak-dev/realms/moh_applications/clients.tf
+++ b/keycloak-dev/realms/moh_applications/clients.tf
@@ -160,8 +160,8 @@ module "UMS-INTEGRATION-TESTS" {
   ORGANIZATIONS-API       = module.ORGANIZATIONS-API
 }
 module "USER-MANAGEMENT" {
-  source                  = "./clients/user-management"
-  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+  source                       = "./clients/user-management"
+  USER-MANAGEMENT-SERVICE      = module.USER-MANAGEMENT-SERVICE
   browser_idp_restriction_flow = local.browser_idp_restriction_flow
 }
 module "HCIM_BCMI" {

--- a/keycloak-dev/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/user-management/main.tf
@@ -28,7 +28,7 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
   authentication_flow_binding_overrides {
     # browser-idp-restriction flow
-    browser_id = "9caca0f9-1c0c-4def-85c6-637d1c8a4d24"
+    browser_id = var.browser_idp_restriction_flow
   }
   login_theme = "moh-app-realm-idp-restriction"
 }

--- a/keycloak-dev/realms/moh_applications/clients/user-management/variables.tf
+++ b/keycloak-dev/realms/moh_applications/clients/user-management/variables.tf
@@ -1,1 +1,2 @@
 variable "USER-MANAGEMENT-SERVICE" {}
+variable "browser_idp_restriction_flow" {}

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -532,3 +532,8 @@ module "HCIM_VCHA" {
 module "HCIM_VPP" {
   source = "./clients/hcim_vpp"
 }
+locals {
+  # ID of the browser-idp-restriction authentication flow in moh_applications DEV.
+  # Used by selected clients, overrides the default browser flow.
+  browser_idp_restriction_flow = "9e34841a-ef45-47d7-a08a-cb65bc9130e0"
+}

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -478,8 +478,8 @@ module "USER-MANAGEMENT-SERVICE" {
   MSPDIRECT-SERVICE = module.MSPDIRECT-SERVICE
 }
 module "USER-MANAGEMENT" {
-  source                  = "./clients/user-management"
-  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+  source                       = "./clients/user-management"
+  USER-MANAGEMENT-SERVICE      = module.USER-MANAGEMENT-SERVICE
   browser_idp_restriction_flow = local.browser_idp_restriction_flow
 }
 module "WEBCAPS" {

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -480,6 +480,7 @@ module "USER-MANAGEMENT-SERVICE" {
 module "USER-MANAGEMENT" {
   source                  = "./clients/user-management"
   USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
 }
 module "WEBCAPS" {
   source = "./clients/webcaps"

--- a/keycloak-test/realms/moh_applications/clients/prp-service/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prp-service/main.tf
@@ -33,6 +33,9 @@ module "client-roles" {
     "Pmp" = {
       "name" = "Pmp"
     },
+    "PRP_LTC" = {
+      "name" = "PRP_LTC"
+    },
     "PRP_MSPQI" = {
       "name" = "PRP_MSPQI"
     },
@@ -57,5 +60,12 @@ module "client-roles" {
     "PRP_ReportSection_PMP" = {
       "name" = "PRP_ReportSection_PMP"
     },
+    "PRP_ReportProgram_LTC" = {
+      "name" = "PRP_ReportProgram_LTC"
+    },
+    "PRP_ReportSection_LTC" = {
+      "name" = "PRP_ReportSection_LTC"
+    },
+
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prp-web/main.tf
@@ -89,6 +89,7 @@ module "scope-mappings" {
     "PRP-SERVICE/Physician"               = var.PRP-SERVICE.ROLES["Physician"].id,
     "PRP-SERVICE/Pharmacist"              = var.PRP-SERVICE.ROLES["Pharmacist"].id,
     "PRP-SERVICE/Pmp"                     = var.PRP-SERVICE.ROLES["Pmp"].id,
+    "PRP-SERVICE/PRP_LTC"                 = var.PRP-SERVICE.ROLES["PRP_LTC"].id,
     "PRP-SERVICE/PRP_MSPQI"               = var.PRP-SERVICE.ROLES["PRP_MSPQI"].id,
     "PRP-SERVICE/PRP_MSPQI_RLS"           = var.PRP-SERVICE.ROLES["PRP_MSPQI_RLS"].id,
     "PRP-SERVICE/PRP_PMP"                 = var.PRP-SERVICE.ROLES["PRP_PMP"].id,
@@ -97,6 +98,8 @@ module "scope-mappings" {
     "PRP-SERVICE/PRP_ReportSection_MSPQI" = var.PRP-SERVICE.ROLES["PRP_ReportSection_MSPQI"].id,
     "PRP-SERVICE/PRP_ReportProgram_PMP"   = var.PRP-SERVICE.ROLES["PRP_ReportProgram_PMP"].id,
     "PRP-SERVICE/PRP_ReportSection_PMP"   = var.PRP-SERVICE.ROLES["PRP_ReportSection_PMP"].id,
+    "PRP-SERVICE/PRP_ReportProgram_LTC"   = var.PRP-SERVICE.ROLES["PRP_ReportProgram_LTC"].id,
+    "PRP-SERVICE/PRP_ReportSection_LTC"   = var.PRP-SERVICE.ROLES["PRP_ReportSection_LTC"].id,
     "LICENCE-STATUS/MOA"                  = var.LICENCE-STATUS.ROLES["MOA"].id
     "LICENCE-STATUS/PRACTITIONER"         = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
     "LICENCE-STATUS/MD"                   = var.LICENCE-STATUS.ROLES["MD"].id

--- a/keycloak-test/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management/main.tf
@@ -27,7 +27,7 @@ resource "keycloak_openid_client" "CLIENT" {
     "+",
   ]
   authentication_flow_binding_overrides {
-    # browser-idp-restriction flow
+    #browser-idp-restriction flow
     browser_id = var.browser_idp_restriction_flow
   }
   login_theme = "moh-app-realm-idp-restriction"

--- a/keycloak-test/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management/main.tf
@@ -26,6 +26,11 @@ resource "keycloak_openid_client" "CLIENT" {
   web_origins = [
     "+",
   ]
+  authentication_flow_binding_overrides {
+    # browser-idp-restriction flow
+    browser_id = var.browser_idp_restriction_flow
+  }
+  login_theme = "moh-app-realm-idp-restriction"
 }
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
@@ -46,6 +51,17 @@ resource "keycloak_openid_group_membership_protocol_mapper" "Group-Membership" {
   add_to_userinfo = false
   add_to_id_token = false
   full_path       = false
+}
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "idir_aad",
+    "email",
+    "profile",
+    "roles",
+    "web-origins"
+  ]
 }
 module "scope-mappings" {
   source    = "../../../../../modules/scope-mappings"

--- a/keycloak-test/realms/moh_applications/clients/user-management/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management/variables.tf
@@ -1,1 +1,2 @@
 variable "USER-MANAGEMENT-SERVICE" {}
+variable "browser_idp_restriction_flow" {}


### PR DESCRIPTION
### Changes being made

Add 3 new PRP roles on TEST. Configure idp-restriction-module on Keycloak TEST environment. Replacing hardcoded browser-flow id with a variable.


### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.