### PR TITLE
apply idp restriction module to cmdb bcer and connect

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -8,7 +8,9 @@ module "ALR" {
   source = "./clients/alr"
 }
 module "BCER-CP" {
-  source = "./clients/bcer-cp"
+  source                       = "./clients/bcer-cp"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
+
 }
 module "BCHCIM" {
   source = "./clients/bchcim"
@@ -18,10 +20,15 @@ module "BULK-USER-UPLOAD" {
   realm-management = module.realm-management
 }
 module "CONNECT" {
-  source = "./clients/connect"
+  source                       = "./clients/connect"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
+
+
 }
 module "CMDB" {
-  source = "./clients/cmdb"
+  source                       = "./clients/cmdb"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
+
 }
 module "DEMO-CLIENT" {
   source = "./clients/demo-client"

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -10,7 +10,6 @@ module "ALR" {
 module "BCER-CP" {
   source                       = "./clients/bcer-cp"
   browser_idp_restriction_flow = local.browser_idp_restriction_flow
-
 }
 module "BCHCIM" {
   source = "./clients/bchcim"
@@ -22,13 +21,10 @@ module "BULK-USER-UPLOAD" {
 module "CONNECT" {
   source                       = "./clients/connect"
   browser_idp_restriction_flow = local.browser_idp_restriction_flow
-
-
 }
 module "CMDB" {
   source                       = "./clients/cmdb"
   browser_idp_restriction_flow = local.browser_idp_restriction_flow
-
 }
 module "DEMO-CLIENT" {
   source = "./clients/demo-client"

--- a/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
@@ -30,7 +30,7 @@ resource "keycloak_openid_client" "CLIENT" {
   web_origins = [
     "+",
   ]
-   authentication_flow_binding_overrides {
+  authentication_flow_binding_overrides {
     #browser-idp-restriction flow
     browser_id = var.browser_idp_restriction_flow
   }

--- a/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
@@ -30,6 +30,23 @@ resource "keycloak_openid_client" "CLIENT" {
   web_origins = [
     "+",
   ]
+   authentication_flow_binding_overrides {
+    #browser-idp-restriction flow
+    browser_id = var.browser_idp_restriction_flow
+  }
+  login_theme = "moh-app-realm-idp-restriction"
+}
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "idir",
+    "phsa",
+    "email",
+    "profile",
+    "roles",
+    "web-origins"
+  ]
 }
 module "client-roles" {
   source    = "../../../../../modules/client-roles"

--- a/keycloak-test/realms/moh_applications/clients/bcer-cp/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/bcer-cp/variables.tf
@@ -1,0 +1,1 @@
+variable "browser_idp_restriction_flow" {}

--- a/keycloak-test/realms/moh_applications/clients/cmdb/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/cmdb/main.tf
@@ -24,4 +24,20 @@ resource "keycloak_openid_client" "CMDB" {
   ]
   web_origins = [
   ]
+  authentication_flow_binding_overrides {
+    #browser-idp-restriction flow
+    browser_id = var.browser_idp_restriction_flow
+  }
+  login_theme = "moh-app-realm-idp-restriction"
+}
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CMDB.realm_id
+  client_id = keycloak_openid_client.CMDB.id
+  default_scopes = [
+    "idir_aad",
+    "email",
+    "profile",
+    "roles",
+    "web-origins"
+  ]
 }

--- a/keycloak-test/realms/moh_applications/clients/cmdb/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/cmdb/main.tf
@@ -35,7 +35,6 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   client_id = keycloak_openid_client.CMDB.id
   default_scopes = [
     "idir",
-    "idir_aad",
     "email",
     "profile",
     "roles",

--- a/keycloak-test/realms/moh_applications/clients/cmdb/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/cmdb/main.tf
@@ -34,6 +34,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   realm_id  = keycloak_openid_client.CMDB.realm_id
   client_id = keycloak_openid_client.CMDB.id
   default_scopes = [
+    "idir",
     "idir_aad",
     "email",
     "profile",

--- a/keycloak-test/realms/moh_applications/clients/cmdb/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/cmdb/variables.tf
@@ -1,0 +1,1 @@
+variable "browser_idp_restriction_flow" {}

--- a/keycloak-test/realms/moh_applications/clients/connect/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/connect/main.tf
@@ -28,7 +28,7 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
   web_origins = [
   ]
-   authentication_flow_binding_overrides {
+  authentication_flow_binding_overrides {
     #browser-idp-restriction flow
     browser_id = var.browser_idp_restriction_flow
   }

--- a/keycloak-test/realms/moh_applications/clients/connect/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/connect/main.tf
@@ -28,6 +28,11 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
   web_origins = [
   ]
+   authentication_flow_binding_overrides {
+    #browser-idp-restriction flow
+    browser_id = var.browser_idp_restriction_flow
+  }
+  login_theme = "moh-app-realm-idp-restriction"
 }
 resource "keycloak_openid_user_attribute_protocol_mapper" "bceid_business_legalName" {
   add_to_id_token = true
@@ -53,6 +58,9 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   default_scopes = [
+    "bceid_business",
+    "idir",
+    "phsa",
     "email",
     "profile",
     "roles",

--- a/keycloak-test/realms/moh_applications/clients/connect/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/connect/variables.tf
@@ -1,0 +1,1 @@
+variable "browser_idp_restriction_flow" {}


### PR DESCRIPTION
### Changes being made

Applying IDP restriction module to BCER, CMDB and CONNECT clients on TEST environment.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.