### PR TITLE
add bulk-removal permissions to registries team

### DIFF
--- a/keycloak-test/realms/moh_applications/groups/registries-connections-team/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/registries-connections-team/main.tf
@@ -8,6 +8,7 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
   group_id = keycloak_group.GROUP.id
 
   role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["bulk-removal"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,


### PR DESCRIPTION
### Changes being made

Assigning bulk-removal permissions to the Registries-Connections Team in Test environment.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.