### PR TITLE
apply idp-restriction module for forms and connect

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients.tf
+++ b/keycloak-dev/realms/moh_applications/clients.tf
@@ -15,7 +15,8 @@ module "BULK-USER-UPLOAD" {
   realm-management = module.realm-management
 }
 module "CONNECT" {
-  source = "./clients/connect"
+  source                       = "./clients/connect"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
 }
 module "DMFT-SERVICE" {
   source       = "./clients/dmft-service"
@@ -29,7 +30,8 @@ module "EMCOD" {
   source = "./clients/emcod"
 }
 module "FORMS" {
-  source = "./clients/forms"
+  source                       = "./clients/forms"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
 }
 module "HCIMWEB" {
   source = "./clients/hcimweb"

--- a/keycloak-dev/realms/moh_applications/clients/connect/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/connect/main.tf
@@ -27,6 +27,11 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
   web_origins = [
   ]
+  authentication_flow_binding_overrides {
+    # browser-idp-restriction flow
+    browser_id = var.browser_idp_restriction_flow
+  }
+  login_theme = "moh-app-realm-idp-restriction"
 }
 resource "keycloak_openid_user_attribute_protocol_mapper" "bceid_business_legalName" {
   add_to_id_token = true
@@ -52,6 +57,9 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   default_scopes = [
+    "bceid_business",
+    "idir_aad",
+    "phsa",
     "email",
     "profile",
     "roles",

--- a/keycloak-dev/realms/moh_applications/clients/connect/variables.tf
+++ b/keycloak-dev/realms/moh_applications/clients/connect/variables.tf
@@ -1,0 +1,1 @@
+variable "browser_idp_restriction_flow" {}

--- a/keycloak-dev/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/forms/main.tf
@@ -26,6 +26,11 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
   web_origins = [
   ]
+  authentication_flow_binding_overrides {
+    # browser-idp-restriction flow
+    browser_id = var.browser_idp_restriction_flow
+  }
+  login_theme = "moh-app-realm-idp-restriction"
 }
 
 resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
@@ -52,6 +57,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   default_scopes = [
+    "idir_aad",
+    "phsa",
     "email",
     "profile",
     "roles",

--- a/keycloak-dev/realms/moh_applications/clients/forms/variables.tf
+++ b/keycloak-dev/realms/moh_applications/clients/forms/variables.tf
@@ -1,0 +1,1 @@
+variable "browser_idp_restriction_flow" {}


### PR DESCRIPTION
### Changes being made

Applying IDP restriction module to CONNECT and FORMS on DEV. Deprecating IDIR - replacing with IDIR_AAD.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.
