### PR TITLE
add sysadmin role to emaccs in test

### DIFF
--- a/keycloak-test/realms/moh_citizen/clients/emaccs/main.tf
+++ b/keycloak-test/realms/moh_citizen/clients/emaccs/main.tf
@@ -47,3 +47,15 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "bceid_user_guid" {
   user_attribute      = "bceid_user_guid"
   realm_id            = keycloak_openid_client.CLIENT.realm_id
 }
+
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "SYSADMIN" = {
+      "name"        = "SYSADMIN"
+      "description" = "System Administrator"
+    },
+  }
+}


### PR DESCRIPTION
### Changes being made

Adding SYSADMIN role to emaccs in test.

### Context

Requested by Adam H.

### Quality Check


- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

