### PR TITLE
add url redirects to test and prod for bcer

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/bcer-cp/main.tf
@@ -21,6 +21,7 @@ resource "keycloak_openid_client" "CLIENT" {
   valid_redirect_uris = [
     "https://bcer.hlth.gov.bc.ca/portal/*",
     "https://drac0atkqiq1j.cloudfront.net/portal/*",
+    "https://bcer-prod.s3.amazonaws.com/*",
   ]
   web_origins = [
     "+",

--- a/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
@@ -26,6 +26,8 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://bcer-dev.hlth.gov.bc.ca/portal/*",
     "https://bcer-test.hlth.gov.bc.ca/portal/*",
     "https://d3naoa5ica8tt3.cloudfront.net/portal/*",
+    "https://bcer-dev.s3.amazonaws.com/*",
+    "https://bcer-test.s3.amazonaws.com/*",
   ]
   web_origins = [
     "+",


### PR DESCRIPTION
### Changes being made

adding two url redirects to test bcer client https://bcer-dev.s3.amazonaws.com
https://bcer-test.s3.amazonaws.com and one url redirect to prod bcer client https://bcer-prod.s3.amazonaws.com

### Context

Changes requested by client.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
