### PR TITLE
add roles to emaccs in test

### DIFF
--- a/keycloak-test/realms/moh_citizen/clients/emaccs/main.tf
+++ b/keycloak-test/realms/moh_citizen/clients/emaccs/main.tf
@@ -57,5 +57,21 @@ module "client-roles" {
       "name"        = "SYSADMIN"
       "description" = "System Administrator"
     },
+    "CA" = {
+      "name"        = "CA"
+      "description" = ""
+    },
+    "CCA" = {
+      "name"        = "CCA"
+      "description" = ""
+    },
+    "DIRECTOR" = {
+      "name"        = "DIRECTOR"
+      "description" = ""
+    },
+    "READONLY" = {
+      "name"        = "READONLY"
+      "description" = ""
+    },
   }
 }


### PR DESCRIPTION
### Changes being made

Adding CA, CCA, DIRECTOR and READONLY roles to EMACCS client in test.

### Context

Requested by Adam H.

### Quality Check


- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

