### PR TITLE
update itsb-access-team permissions

### DIFF
--- a/keycloak-dev/realms/moh_applications/groups/itsb-access-team/main.tf
+++ b/keycloak-dev/realms/moh_applications/groups/itsb-access-team/main.tf
@@ -14,6 +14,7 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-bcer-cp"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pho-rsc"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pho-rsc-groups"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-dbaac-portal"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-hibc-service-bc-portal"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-sfdc"].id,

--- a/keycloak-prod/realms/moh_applications/groups/itsb-access-team/main.tf
+++ b/keycloak-prod/realms/moh_applications/groups/itsb-access-team/main.tf
@@ -23,6 +23,7 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-maid"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-miwt"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pho-rsc"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-pho-rsc-groups"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-dbaac-portal"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-hibc-service-bc-portal"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-sa-sfdc"].id,


### PR DESCRIPTION
### Changes being made

Add view-client-pho-rsc-groups permission to ITSB on dev and PROD

### Context

The ITSB group was missing a permission to manage pho-rsc groups (it can only manage pho-rsc roles). Next task would be to remove PHO-RSC-MANAGEMENT groups, as it duplicates permissions and may be misleading.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.