### PR TITLE
Update EMACCS role descriptions to match what was previously in LDAPAdmin

### DIFF
--- a/keycloak-test/realms/moh_citizen/clients/emaccs/main.tf
+++ b/keycloak-test/realms/moh_citizen/clients/emaccs/main.tf
@@ -59,19 +59,19 @@ module "client-roles" {
     },
     "CA" = {
       "name"        = "CA"
-      "description" = ""
+      "description" = "Clinical Advisor"
     },
     "CCA" = {
       "name"        = "CCA"
-      "description" = ""
+      "description" = "Continuing Competence Analyst"
     },
     "DIRECTOR" = {
       "name"        = "DIRECTOR"
-      "description" = ""
+      "description" = "Director"
     },
     "READONLY" = {
       "name"        = "READONLY"
-      "description" = ""
+      "description" = "Read Only"
     },
   }
 }


### PR DESCRIPTION
### Changes being made

Update EMACCS role descriptions to match what was previously in LDAPAdmin.

### Context

Changes related to EMACCS client on-boarding.

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^1]

[^1]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)