### PR TITLE
emaccs-ums service account

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -57,6 +57,10 @@ module "EDRD-PORTAL" {
 module "EHPR" {
   source = "./clients/ehpr"
 }
+module "EMACCS-UMS" {
+  source                  = "./clients/emaccs-ums"
+  USER-MANAGEMENT-SERVICE = module.USER-MANAGEMENT-SERVICE
+}
 module "EMCOD" {
   source = "./clients/emcod"
 }

--- a/keycloak-test/realms/moh_applications/clients/emaccs-ums/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/emaccs-ums/main.tf
@@ -1,0 +1,48 @@
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = "300"
+  access_type                         = "CONFIDENTIAL"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "EMACCS-UMS"
+  consent_required                    = false
+  description                         = "Service account that allows EMACCS to call UMS API"
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = false
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = ""
+  pkce_code_challenge_method          = ""
+  realm_id                            = "moh_applications"
+  service_accounts_enabled            = true
+  standard_flow_enabled               = false
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+  ]
+  web_origins = [
+  ]
+}
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "USER-MANAGEMENT-SERVICE/view-clients" = var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
+  }
+}
+module "service-account-roles" {
+  source                  = "../../../../../modules/service-account-roles"
+  realm_id                = keycloak_openid_client.CLIENT.realm_id
+  client_id               = keycloak_openid_client.CLIENT.id
+  service_account_user_id = keycloak_openid_client.CLIENT.service_account_user_id
+  realm_roles = {
+    "default-roles-moh_applications" = "default-roles-moh_applications",
+  }
+  client_roles = {
+    "USER-MANAGEMENT-SERVICE/view-clients" = {
+      "client_id" = var.USER-MANAGEMENT-SERVICE.CLIENT.id,
+      "role_id"   = "view-clients"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/emaccs-ums/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/emaccs-ums/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/emaccs-ums/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/emaccs-ums/variables.tf
@@ -1,0 +1,1 @@
+variable "USER-MANAGEMENT-SERVICE" {}

--- a/keycloak-test/realms/moh_applications/clients/emaccs-ums/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/emaccs-ums/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Creating EMACCS-UMS client, a service account that will allow EMACCS to call UMS API. 
Flow: EMACCS-UMS obtains token from moh_applications realm, passes it in a request to UMS API that fetches data from moh_citizen.

### Context

EMACCS client onboarding.

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided.
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.