### PR TITLE
create florizel-training client

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -67,6 +67,9 @@ module "EMCOD" {
 module "FLORIZEL" {
   source = "./clients/florizel"
 }
+module "FLORIZEL-TRAINING" {
+  source = "./clients/florizel-training"
+}
 module "FMDB" {
   source = "./clients/fmdb"
 }

--- a/keycloak-test/realms/moh_applications/clients/florizel-training/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/florizel-training/main.tf
@@ -1,0 +1,103 @@
+resource "keycloak_saml_client" "CLIENT" {
+  realm_id                  = "moh_applications"
+  client_id                 = "FLORIZEL-TRAINING"
+  name                      = "FLORIZEL TRAINING"
+  description               = "A health management platform providing medical triage services - training environment"
+  enabled                   = true
+  include_authn_statement   = true
+  sign_documents            = true
+  sign_assertions           = false
+  signature_algorithm       = "RSA_SHA256"
+  signature_key_name        = "NONE"
+  canonicalization_method   = "EXCLUSIVE"
+  encrypt_assertions        = false
+  client_signature_required = false
+  force_post_binding        = true
+  front_channel_logout      = true
+  force_name_id_format      = true
+  name_id_format            = "persistent"
+  full_scope_allowed        = false
+
+  valid_redirect_uris = [
+    "https://hlbc-training.fonemedhms.com/*",
+  ]
+  base_url = "https://hlbc-training.fonemedhms.com"
+
+  assertion_consumer_redirect_url = "https://hlbc-training.fonemedhms.com/adminusers/auth/saml/callback"
+  assertion_consumer_post_url     = "https://hlbc-training.fonemedhms.com/adminusers/auth/saml/callback"
+}
+
+
+resource "keycloak_saml_user_property_protocol_mapper" "saml_user_email_mapper" {
+  realm_id                   = keycloak_saml_client.CLIENT.realm_id
+  client_id                  = keycloak_saml_client.CLIENT.id
+  name                       = "email"
+  user_property              = "email"
+  saml_attribute_name        = "email"
+  friendly_name              = "email"
+  saml_attribute_name_format = "Basic"
+}
+
+resource "keycloak_saml_user_property_protocol_mapper" "saml_user_last_name_mapper" {
+  realm_id                   = keycloak_saml_client.CLIENT.realm_id
+  client_id                  = keycloak_saml_client.CLIENT.id
+  name                       = "lastName"
+  user_property              = "lastName"
+  saml_attribute_name        = "lastName"
+  friendly_name              = "lastName"
+  saml_attribute_name_format = "Basic"
+}
+
+resource "keycloak_saml_user_property_protocol_mapper" "saml_user_first_name_mapper" {
+  realm_id                   = keycloak_saml_client.CLIENT.realm_id
+  client_id                  = keycloak_saml_client.CLIENT.id
+  name                       = "firstName"
+  user_property              = "firstName"
+  saml_attribute_name        = "firstName"
+  friendly_name              = "firstName"
+  saml_attribute_name_format = "Basic"
+}
+
+resource "keycloak_role" "observer_role" {
+  realm_id  = keycloak_saml_client.CLIENT.realm_id
+  client_id = keycloak_saml_client.CLIENT.id
+  name      = "Observer"
+}
+
+resource "keycloak_role" "patient_role" {
+  realm_id  = keycloak_saml_client.CLIENT.realm_id
+  client_id = keycloak_saml_client.CLIENT.id
+  name      = "Patient"
+}
+
+resource "keycloak_role" "non_clinical_role" {
+  realm_id  = keycloak_saml_client.CLIENT.realm_id
+  client_id = keycloak_saml_client.CLIENT.id
+  name      = "Non-Clinical"
+}
+
+resource "keycloak_role" "clinical_role" {
+  realm_id  = keycloak_saml_client.CLIENT.realm_id
+  client_id = keycloak_saml_client.CLIENT.id
+  name      = "Clinical"
+}
+
+resource "keycloak_role" "clinical_manager_role" {
+  realm_id  = keycloak_saml_client.CLIENT.realm_id
+  client_id = keycloak_saml_client.CLIENT.id
+  name      = "Clinical Manager"
+}
+
+resource "keycloak_generic_client_protocol_mapper" "saml_role_list_mapper" {
+  realm_id        = keycloak_saml_client.CLIENT.realm_id
+  client_id       = keycloak_saml_client.CLIENT.id
+  name            = "role list"
+  protocol        = "saml"
+  protocol_mapper = "saml-role-list-mapper"
+  config = {
+    "attribute.name"       = "Roles"
+    "attribute.nameformat" = "Basic"
+    "friendly.name"        = "Roles"
+    "single"               = "true"
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/florizel-training/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/florizel-training/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_saml_client.CLIENT
+}

--- a/keycloak-test/realms/moh_applications/clients/florizel-training/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/florizel-training/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Creating Florizel-Training client. Copy of Florizel, but with different home and ACS URLs.

### Context

Florizel client onboarding

### Quality Check

- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 