### PR TITLE
promote florizel to prod

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients.tf
+++ b/keycloak-prod/realms/moh_applications/clients.tf
@@ -52,6 +52,9 @@ module "EMCOD" {
 module "EHPR" {
   source = "./clients/ehpr"
 }
+module "FLORIZEL" {
+  source = "./clients/florizel"
+}
 module "FMDB" {
   source = "./clients/fmdb"
 }

--- a/keycloak-prod/realms/moh_applications/clients/florizel/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/florizel/main.tf
@@ -1,8 +1,8 @@
 resource "keycloak_saml_client" "CLIENT" {
   realm_id                  = "moh_applications"
   client_id                 = "FLORIZEL"
-  name                      = "FLORIZEL TEST"
-  description               = "A health management platform providing medical triage services - test environment"
+  name                      = "FLORIZEL"
+  description               = "A health management platform providing medical triage services"
   enabled                   = true
   include_authn_statement   = true
   sign_documents            = true

--- a/keycloak-prod/realms/moh_applications/clients/florizel/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/florizel/main.tf
@@ -1,0 +1,103 @@
+resource "keycloak_saml_client" "CLIENT" {
+  realm_id                  = "moh_applications"
+  client_id                 = "FLORIZEL"
+  name                      = "FLORIZEL TEST"
+  description               = "A health management platform providing medical triage services - test environment"
+  enabled                   = true
+  include_authn_statement   = true
+  sign_documents            = true
+  sign_assertions           = false
+  signature_algorithm       = "RSA_SHA256"
+  signature_key_name        = "NONE"
+  canonicalization_method   = "EXCLUSIVE"
+  encrypt_assertions        = false
+  client_signature_required = false
+  force_post_binding        = true
+  front_channel_logout      = true
+  force_name_id_format      = true
+  name_id_format            = "persistent"
+  full_scope_allowed        = false
+
+  valid_redirect_uris = [
+    "https://hlbc.fonemedhms.com/*",
+  ]
+  base_url = "https://hlbc.fonemedhms.com"
+
+  assertion_consumer_redirect_url = "https://hlbc.fonemedhms.com/adminusers/auth/saml/callback"
+  assertion_consumer_post_url     = "https://hlbc.fonemedhms.com/adminusers/auth/saml/callback"
+}
+
+
+resource "keycloak_saml_user_property_protocol_mapper" "saml_user_email_mapper" {
+  realm_id                   = keycloak_saml_client.CLIENT.realm_id
+  client_id                  = keycloak_saml_client.CLIENT.id
+  name                       = "email"
+  user_property              = "email"
+  saml_attribute_name        = "email"
+  friendly_name              = "email"
+  saml_attribute_name_format = "Basic"
+}
+
+resource "keycloak_saml_user_property_protocol_mapper" "saml_user_last_name_mapper" {
+  realm_id                   = keycloak_saml_client.CLIENT.realm_id
+  client_id                  = keycloak_saml_client.CLIENT.id
+  name                       = "lastName"
+  user_property              = "lastName"
+  saml_attribute_name        = "lastName"
+  friendly_name              = "lastName"
+  saml_attribute_name_format = "Basic"
+}
+
+resource "keycloak_saml_user_property_protocol_mapper" "saml_user_first_name_mapper" {
+  realm_id                   = keycloak_saml_client.CLIENT.realm_id
+  client_id                  = keycloak_saml_client.CLIENT.id
+  name                       = "firstName"
+  user_property              = "firstName"
+  saml_attribute_name        = "firstName"
+  friendly_name              = "firstName"
+  saml_attribute_name_format = "Basic"
+}
+
+resource "keycloak_role" "observer_role" {
+  realm_id  = keycloak_saml_client.CLIENT.realm_id
+  client_id = keycloak_saml_client.CLIENT.id
+  name      = "Observer"
+}
+
+resource "keycloak_role" "patient_role" {
+  realm_id  = keycloak_saml_client.CLIENT.realm_id
+  client_id = keycloak_saml_client.CLIENT.id
+  name      = "Patient"
+}
+
+resource "keycloak_role" "non_clinical_role" {
+  realm_id  = keycloak_saml_client.CLIENT.realm_id
+  client_id = keycloak_saml_client.CLIENT.id
+  name      = "Non-Clinical"
+}
+
+resource "keycloak_role" "clinical_role" {
+  realm_id  = keycloak_saml_client.CLIENT.realm_id
+  client_id = keycloak_saml_client.CLIENT.id
+  name      = "Clinical"
+}
+
+resource "keycloak_role" "clinical_manager_role" {
+  realm_id  = keycloak_saml_client.CLIENT.realm_id
+  client_id = keycloak_saml_client.CLIENT.id
+  name      = "Clinical Manager"
+}
+
+resource "keycloak_generic_client_protocol_mapper" "saml_role_list_mapper" {
+  realm_id        = keycloak_saml_client.CLIENT.realm_id
+  client_id       = keycloak_saml_client.CLIENT.id
+  name            = "role list"
+  protocol        = "saml"
+  protocol_mapper = "saml-role-list-mapper"
+  config = {
+    "attribute.name"       = "Role"
+    "attribute.nameformat" = "Basic"
+    "friendly.name"        = "Role"
+    "single"               = "true"
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/florizel/outputs.tf
+++ b/keycloak-prod/realms/moh_applications/clients/florizel/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_saml_client.CLIENT
+}

--- a/keycloak-prod/realms/moh_applications/clients/florizel/versions.tf
+++ b/keycloak-prod/realms/moh_applications/clients/florizel/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-prod/realms/moh_applications/clients/user-management-service/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/user-management-service/main.tf
@@ -70,6 +70,12 @@ module "client-roles" {
     "view-client-emcod" = {
       "name" = "view-client-emcod"
     },
+    "view-client-florizel" = {
+      "name" = "view-client-florizel"
+    },
+    "view-client-florizel-training" = {
+      "name" = "view-client-florizel-training"
+    },
     "view-client-fmdb" = {
       "name" = "view-client-fmdb"
     },

--- a/keycloak-prod/realms/moh_applications/clients/user-management-service/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/user-management-service/main.tf
@@ -73,9 +73,6 @@ module "client-roles" {
     "view-client-florizel" = {
       "name" = "view-client-florizel"
     },
-    "view-client-florizel-training" = {
-      "name" = "view-client-florizel-training"
-    },
     "view-client-fmdb" = {
       "name" = "view-client-fmdb"
     },

--- a/keycloak-prod/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/user-management/main.tf
@@ -66,6 +66,8 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-client-edrd"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-edrd"].id,
     "USER-MANAGEMENT-SERVICE/view-client-edrd-portal"               = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-edrd-portal"].id,
     "USER-MANAGEMENT-SERVICE/view-client-emcod"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-emcod"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-florizel"                  = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-florizel"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-florizel-training"         = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-training"].id,
     "USER-MANAGEMENT-SERVICE/view-client-fmdb"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-fmdb"].id,
     "USER-MANAGEMENT-SERVICE/view-client-gis"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-gis"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hamis"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hamis"].id,

--- a/keycloak-prod/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/user-management/main.tf
@@ -67,7 +67,6 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-client-edrd-portal"               = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-edrd-portal"].id,
     "USER-MANAGEMENT-SERVICE/view-client-emcod"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-emcod"].id,
     "USER-MANAGEMENT-SERVICE/view-client-florizel"                  = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-florizel"].id,
-    "USER-MANAGEMENT-SERVICE/view-client-florizel-training"         = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-training"].id,
     "USER-MANAGEMENT-SERVICE/view-client-fmdb"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-fmdb"].id,
     "USER-MANAGEMENT-SERVICE/view-client-gis"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-gis"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hamis"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hamis"].id,

--- a/keycloak-test/realms/moh_applications/clients/user-management-service/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management-service/main.tf
@@ -76,6 +76,12 @@ module "client-roles" {
     "view-client-emcod" = {
       "name" = "view-client-emcod"
     },
+    "view-client-florizel" = {
+      "name" = "view-client-florizel"
+    },
+    "view-client-florizel-training" = {
+      "name" = "view-client-florizel-training"
+    },
     "view-client-fmdb" = {
       "name" = "view-client-fmdb"
     },

--- a/keycloak-test/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management/main.tf
@@ -84,6 +84,8 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-client-edrd"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-edrd"].id,
     "USER-MANAGEMENT-SERVICE/view-client-edrd-portal"               = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-edrd-portal"].id,
     "USER-MANAGEMENT-SERVICE/view-client-emcod"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-emcod"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-florizel"                  = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-florizel"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-florizel-training"         = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-training"].id,
     "USER-MANAGEMENT-SERVICE/view-client-fmdb"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-fmdb"].id,
     "USER-MANAGEMENT-SERVICE/view-client-gis"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-gis"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hamis"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hamis"].id,

--- a/keycloak-test/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management/main.tf
@@ -85,7 +85,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-client-edrd-portal"               = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-edrd-portal"].id,
     "USER-MANAGEMENT-SERVICE/view-client-emcod"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-emcod"].id,
     "USER-MANAGEMENT-SERVICE/view-client-florizel"                  = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-florizel"].id,
-    "USER-MANAGEMENT-SERVICE/view-client-florizel-training"         = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-training"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-florizel-training"         = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-florizel-training"].id,
     "USER-MANAGEMENT-SERVICE/view-client-fmdb"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-fmdb"].id,
     "USER-MANAGEMENT-SERVICE/view-client-gis"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-gis"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hamis"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hamis"].id,


### PR DESCRIPTION
### Changes being made

Promote Florizel to Prod. Enable Florizel roles assignment  through UMC in Test and Production

### Context

Florizel client onboarding

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [x] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)
