### PR TITLE
adding new IDP claim to hspp and hsiar in test

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
@@ -46,6 +46,17 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
+  add_to_access_token = true
+  add_to_id_token     = true
+  claim_name          = "identity_provider"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "IDP"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+  session_note        = "identity_provider"
+}
+
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -55,6 +55,17 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "idir_displayName" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
+  add_to_access_token = true
+  add_to_id_token     = true
+  claim_name          = "identity_provider"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "IDP"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+  session_note        = "identity_provider"
+}
+
 resource "keycloak_openid_user_attribute_protocol_mapper" "idir_mailboxOrgCode" {
   add_to_id_token = true
   add_to_userinfo = true


### PR DESCRIPTION
Adding new identity_provider claim to hspp and hsiar in test env. claim already exists in prp web.

Please include a short summary of the change.

### Context

Change requested by client.

### Quality Check


- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
