### PR TITLE
Create Yukon AAD scope in DEV for IDP restriction module use.

### DIFF
--- a/keycloak-dev/realms/moh_applications/clientScopes.tf
+++ b/keycloak-dev/realms/moh_applications/clientScopes.tf
@@ -52,11 +52,16 @@ resource "keycloak_openid_client_scope" "bcsc_mspdirect_openid_client_scope" {
   description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with BC Services Card for MSPDirect."
 }
 
-
 resource "keycloak_openid_client_scope" "moh_idp_openid_client_scope" {
   realm_id    = "moh_applications"
   name        = "moh_idp"
   description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with Keycloak."
+}
+
+resource "keycloak_openid_client_scope" "yukon_aad_openid_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "yukon_aad"
+  description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with Yukon MFA."
 }
 
 resource "keycloak_saml_client_scope" "idir_saml_client_scope" {
@@ -117,4 +122,10 @@ resource "keycloak_saml_client_scope" "moh_idp_openid_client_scope" {
   realm_id    = "moh_applications"
   name        = "moh_idp-saml"
   description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with Keycloak."
+}
+
+resource "keycloak_saml_client_scope" "yukon_aad_saml_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "yukon_aad-saml"
+  description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with Yukon MFA."
 }


### PR DESCRIPTION
### Changes being made

Add a `yukon_aad` scope to the `moh_applications` realm in DEV for use by the IDP restriction module.

### Context

This scope may be used by any client in conjunction with the IDP restriction module to restrict that client to using specific IDPs for login.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]