### PR TITLE
adding yukon aad scope in test for IDP restriction moduel

### DIFF
--- a/keycloak-test/realms/moh_applications/clientScopes.tf
+++ b/keycloak-test/realms/moh_applications/clientScopes.tf
@@ -64,11 +64,16 @@ resource "keycloak_openid_client_scope" "bcsc_prime_openid_client_scope" {
   description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with BC Services Card for PRIME."
 }
 
-
 resource "keycloak_openid_client_scope" "moh_idp_openid_client_scope" {
   realm_id    = "moh_applications"
   name        = "moh_idp"
   description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with Keycloak."
+}
+
+resource "keycloak_openid_client_scope" "yukon_aad_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "yukon_aad"
+  description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with Yukon MFA."
 }
 
 resource "keycloak_saml_client_scope" "idir_saml_client_scope" {
@@ -141,4 +146,10 @@ resource "keycloak_saml_client_scope" "moh_idp_openid_client_scope" {
   realm_id    = "moh_applications"
   name        = "moh_idp-saml"
   description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with Keycloak."
+}
+
+resource "keycloak_saml_client_scope" "yukon_aad_saml_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "yukon_aad-saml"
+  description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with Yukon MFA."
 }


### PR DESCRIPTION
### Changes being made

Adding yukon_aad scope to moh_applications realm in test for use of IDP restriction module.

### Context

This scope may be used by any client in conjunction with the IDP restriction module to restrict that client to using specific IDPs for login. Test environment.

### Quality Check


- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

