### PR TITLE
adding license status and identity provider claim to hspp and hsiar

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients.tf
+++ b/keycloak-prod/realms/moh_applications/clients.tf
@@ -131,11 +131,11 @@ module "HSCIS" {
   source = "./clients/hscis"
 }
 module "HSIAR" {
-  source = "./clients/hsiar"
+  source         = "./clients/hsiar"
   LICENCE-STATUS = module.LICENCE-STATUS
 }
 module "HSPP" {
-  source = "./clients/hspp"
+  source         = "./clients/hspp"
   LICENCE-STATUS = module.LICENCE-STATUS
 }
 module "ICY" {

--- a/keycloak-prod/realms/moh_applications/clients.tf
+++ b/keycloak-prod/realms/moh_applications/clients.tf
@@ -132,9 +132,11 @@ module "HSCIS" {
 }
 module "HSIAR" {
   source = "./clients/hsiar"
+  LICENCE-STATUS = module.LICENCE-STATUS
 }
 module "HSPP" {
   source = "./clients/hspp"
+  LICENCE-STATUS = module.LICENCE-STATUS
 }
 module "ICY" {
   source = "./clients/icy"

--- a/keycloak-prod/realms/moh_applications/clients/hsiar/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hsiar/main.tf
@@ -42,6 +42,42 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
+  add_to_access_token = true
+  add_to_id_token     = true
+  claim_name          = "identity_provider"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "IDP"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+  session_note        = "identity_provider"
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "licence_status_role_mapper" {
+  add_to_access_token         = true
+  add_to_id_token             = true
+  claim_name                  = "licence_status"
+  claim_value_type            = "String"
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "LICENCE-STATUS"
+  multivalued                 = true
+  name                        = "licence status"
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}
+
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "LICENCE-STATUS/MOA"                  = var.LICENCE-STATUS.ROLES["MOA"].id
+    "LICENCE-STATUS/PRACTITIONER"         = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
+    "LICENCE-STATUS/MD"                   = var.LICENCE-STATUS.ROLES["MD"].id
+    "LICENCE-STATUS/RNP"                  = var.LICENCE-STATUS.ROLES["RNP"].id
+    "LICENCE-STATUS/PHARM"                = var.LICENCE-STATUS.ROLES["PHARM"].id
+  }
+}
+
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-prod/realms/moh_applications/clients/hsiar/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hsiar/main.tf
@@ -70,11 +70,11 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "LICENCE-STATUS/MOA"                  = var.LICENCE-STATUS.ROLES["MOA"].id
-    "LICENCE-STATUS/PRACTITIONER"         = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
-    "LICENCE-STATUS/MD"                   = var.LICENCE-STATUS.ROLES["MD"].id
-    "LICENCE-STATUS/RNP"                  = var.LICENCE-STATUS.ROLES["RNP"].id
-    "LICENCE-STATUS/PHARM"                = var.LICENCE-STATUS.ROLES["PHARM"].id
+    "LICENCE-STATUS/MOA"          = var.LICENCE-STATUS.ROLES["MOA"].id
+    "LICENCE-STATUS/PRACTITIONER" = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
+    "LICENCE-STATUS/MD"           = var.LICENCE-STATUS.ROLES["MD"].id
+    "LICENCE-STATUS/RNP"          = var.LICENCE-STATUS.ROLES["RNP"].id
+    "LICENCE-STATUS/PHARM"        = var.LICENCE-STATUS.ROLES["PHARM"].id
   }
 }
 

--- a/keycloak-prod/realms/moh_applications/clients/hsiar/variables.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hsiar/variables.tf
@@ -1,0 +1,1 @@
+variable "LICENCE-STATUS" {}

--- a/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
@@ -76,11 +76,11 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "LICENCE-STATUS/MOA"                  = var.LICENCE-STATUS.ROLES["MOA"].id
-    "LICENCE-STATUS/PRACTITIONER"         = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
-    "LICENCE-STATUS/MD"                   = var.LICENCE-STATUS.ROLES["MD"].id
-    "LICENCE-STATUS/RNP"                  = var.LICENCE-STATUS.ROLES["RNP"].id
-    "LICENCE-STATUS/PHARM"                = var.LICENCE-STATUS.ROLES["PHARM"].id
+    "LICENCE-STATUS/MOA"          = var.LICENCE-STATUS.ROLES["MOA"].id
+    "LICENCE-STATUS/PRACTITIONER" = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
+    "LICENCE-STATUS/MD"           = var.LICENCE-STATUS.ROLES["MD"].id
+    "LICENCE-STATUS/RNP"          = var.LICENCE-STATUS.ROLES["RNP"].id
+    "LICENCE-STATUS/PHARM"        = var.LICENCE-STATUS.ROLES["PHARM"].id
   }
 }
 

--- a/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
@@ -38,6 +38,17 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
+  add_to_access_token = true
+  add_to_id_token     = true
+  claim_name          = "identity_provider"
+  claim_value_type    = "String"
+  client_id           = keycloak_openid_client.CLIENT.id
+  name                = "IDP"
+  realm_id            = keycloak_openid_client.CLIENT.realm_id
+  session_note        = "identity_provider"
+}
+
 resource "keycloak_openid_user_attribute_protocol_mapper" "idir_displayName" {
   add_to_id_token = true
   add_to_userinfo = true
@@ -46,6 +57,31 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "idir_displayName" {
   name            = "idir_displayName"
   user_attribute  = "idir_displayName"
   realm_id        = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_user_client_role_protocol_mapper" "licence_status_role_mapper" {
+  add_to_access_token         = true
+  add_to_id_token             = true
+  claim_name                  = "licence_status"
+  claim_value_type            = "String"
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "LICENCE-STATUS"
+  multivalued                 = true
+  name                        = "licence status"
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}
+
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "LICENCE-STATUS/MOA"                  = var.LICENCE-STATUS.ROLES["MOA"].id
+    "LICENCE-STATUS/PRACTITIONER"         = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
+    "LICENCE-STATUS/MD"                   = var.LICENCE-STATUS.ROLES["MD"].id
+    "LICENCE-STATUS/RNP"                  = var.LICENCE-STATUS.ROLES["RNP"].id
+    "LICENCE-STATUS/PHARM"                = var.LICENCE-STATUS.ROLES["PHARM"].id
+  }
 }
 
 module "client-roles" {

--- a/keycloak-prod/realms/moh_applications/clients/hspp/variables.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/variables.tf
@@ -1,0 +1,1 @@
+variable "LICENCE-STATUS" {}

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -154,9 +154,11 @@ module "HSCIS" {
 }
 module "HSIAR" {
   source = "./clients/hsiar"
+  LICENCE-STATUS = module.LICENCE-STATUS
 }
 module "HSPP" {
   source = "./clients/hspp"
+  LICENCE-STATUS = module.LICENCE-STATUS
 }
 module "ICY" {
   source = "./clients/icy"

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -153,11 +153,11 @@ module "HSCIS" {
   source = "./clients/hscis"
 }
 module "HSIAR" {
-  source = "./clients/hsiar"
+  source         = "./clients/hsiar"
   LICENCE-STATUS = module.LICENCE-STATUS
 }
 module "HSPP" {
-  source = "./clients/hspp"
+  source         = "./clients/hspp"
   LICENCE-STATUS = module.LICENCE-STATUS
 }
 module "ICY" {

--- a/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
@@ -74,11 +74,11 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "LICENCE-STATUS/MOA"                  = var.LICENCE-STATUS.ROLES["MOA"].id
-    "LICENCE-STATUS/PRACTITIONER"         = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
-    "LICENCE-STATUS/MD"                   = var.LICENCE-STATUS.ROLES["MD"].id
-    "LICENCE-STATUS/RNP"                  = var.LICENCE-STATUS.ROLES["RNP"].id
-    "LICENCE-STATUS/PHARM"                = var.LICENCE-STATUS.ROLES["PHARM"].id
+    "LICENCE-STATUS/MOA"          = var.LICENCE-STATUS.ROLES["MOA"].id
+    "LICENCE-STATUS/PRACTITIONER" = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
+    "LICENCE-STATUS/MD"           = var.LICENCE-STATUS.ROLES["MD"].id
+    "LICENCE-STATUS/RNP"          = var.LICENCE-STATUS.ROLES["RNP"].id
+    "LICENCE-STATUS/PHARM"        = var.LICENCE-STATUS.ROLES["PHARM"].id
   }
 }
 

--- a/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hsiar/main.tf
@@ -57,6 +57,31 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   session_note        = "identity_provider"
 }
 
+resource "keycloak_openid_user_client_role_protocol_mapper" "licence_status_role_mapper" {
+  add_to_access_token         = true
+  add_to_id_token             = true
+  claim_name                  = "licence_status"
+  claim_value_type            = "String"
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "LICENCE-STATUS"
+  multivalued                 = true
+  name                        = "licence status"
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}
+
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "LICENCE-STATUS/MOA"                  = var.LICENCE-STATUS.ROLES["MOA"].id
+    "LICENCE-STATUS/PRACTITIONER"         = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
+    "LICENCE-STATUS/MD"                   = var.LICENCE-STATUS.ROLES["MD"].id
+    "LICENCE-STATUS/RNP"                  = var.LICENCE-STATUS.ROLES["RNP"].id
+    "LICENCE-STATUS/PHARM"                = var.LICENCE-STATUS.ROLES["PHARM"].id
+  }
+}
+
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-test/realms/moh_applications/clients/hsiar/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/hsiar/variables.tf
@@ -1,0 +1,1 @@
+variable "LICENCE-STATUS" {}

--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -93,11 +93,11 @@ module "scope-mappings" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   roles = {
-    "LICENCE-STATUS/MOA"                  = var.LICENCE-STATUS.ROLES["MOA"].id
-    "LICENCE-STATUS/PRACTITIONER"         = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
-    "LICENCE-STATUS/MD"                   = var.LICENCE-STATUS.ROLES["MD"].id
-    "LICENCE-STATUS/RNP"                  = var.LICENCE-STATUS.ROLES["RNP"].id
-    "LICENCE-STATUS/PHARM"                = var.LICENCE-STATUS.ROLES["PHARM"].id
+    "LICENCE-STATUS/MOA"          = var.LICENCE-STATUS.ROLES["MOA"].id
+    "LICENCE-STATUS/PRACTITIONER" = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
+    "LICENCE-STATUS/MD"           = var.LICENCE-STATUS.ROLES["MD"].id
+    "LICENCE-STATUS/RNP"          = var.LICENCE-STATUS.ROLES["RNP"].id
+    "LICENCE-STATUS/PHARM"        = var.LICENCE-STATUS.ROLES["PHARM"].id
   }
 }
 

--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -76,6 +76,31 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "idir_mailboxOrgCode" 
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_openid_user_client_role_protocol_mapper" "licence_status_role_mapper" {
+  add_to_access_token         = true
+  add_to_id_token             = true
+  claim_name                  = "licence_status"
+  claim_value_type            = "String"
+  client_id                   = keycloak_openid_client.CLIENT.id
+  client_id_for_role_mappings = "LICENCE-STATUS"
+  multivalued                 = true
+  name                        = "licence status"
+  realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}
+
+module "scope-mappings" {
+  source    = "../../../../../modules/scope-mappings"
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  roles = {
+    "LICENCE-STATUS/MOA"                  = var.LICENCE-STATUS.ROLES["MOA"].id
+    "LICENCE-STATUS/PRACTITIONER"         = var.LICENCE-STATUS.ROLES["PRACTITIONER"].id
+    "LICENCE-STATUS/MD"                   = var.LICENCE-STATUS.ROLES["MD"].id
+    "LICENCE-STATUS/RNP"                  = var.LICENCE-STATUS.ROLES["RNP"].id
+    "LICENCE-STATUS/PHARM"                = var.LICENCE-STATUS.ROLES["PHARM"].id
+  }
+}
+
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
   client_id = keycloak_openid_client.CLIENT.id

--- a/keycloak-test/realms/moh_applications/clients/hspp/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/variables.tf
@@ -1,0 +1,1 @@
+variable "LICENCE-STATUS" {}


### PR DESCRIPTION
### Changes being made

Adding license status and identity provider claim to hspp and hsiar to test and prod environment. Also adding license status roles.

### Context

Changes requested by client. Also for PRP - this seems to exist already.

### Quality Check


- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
