### PR TITLE
update florizel admin permissions

### DIFF
--- a/keycloak-prod/realms/moh_applications/groups/florizel-management/main.tf
+++ b/keycloak-prod/realms/moh_applications/groups/florizel-management/main.tf
@@ -8,6 +8,7 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
   group_id = keycloak_group.GROUP.id
 
   role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,

--- a/keycloak-test/realms/moh_applications/groups/florizel-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/florizel-management/main.tf
@@ -8,6 +8,7 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
   group_id = keycloak_group.GROUP.id
 
   role_ids = [
+    var.USER-MANAGEMENT-SERVICE.ROLES["create-user"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,


### PR DESCRIPTION
### Changes being made

Allowing FLORIZEL admins to pre-register users.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.
