### PR TITLE
introduce idp restriction module to genesys and florizel

### DIFF
--- a/keycloak-dev/realms/moh_applications/clientScopes.tf
+++ b/keycloak-dev/realms/moh_applications/clientScopes.tf
@@ -118,7 +118,7 @@ resource "keycloak_saml_client_scope" "bcsc_mspdirect_saml_client_scope" {
   description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with BC Services Card for MSPDirect."
 }
 
-resource "keycloak_saml_client_scope" "moh_idp_openid_client_scope" {
+resource "keycloak_saml_client_scope" "moh_idp_saml_client_scope" {
   realm_id    = "moh_applications"
   name        = "moh_idp-saml"
   description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with Keycloak."

--- a/keycloak-prod/realms/moh_applications/clientScopes.tf
+++ b/keycloak-prod/realms/moh_applications/clientScopes.tf
@@ -71,6 +71,12 @@ resource "keycloak_openid_client_scope" "moh_idp_openid_client_scope" {
   description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with Keycloak."
 }
 
+resource "keycloak_openid_client_scope" "yukon_aad_openid_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "yukon_aad"
+  description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with Yukon MFA."
+}
+
 resource "keycloak_saml_client_scope" "idir_saml_client_scope" {
   realm_id    = "moh_applications"
   name        = "idir-saml"
@@ -137,8 +143,14 @@ resource "keycloak_saml_client_scope" "bcsc_prime_saml_client_scope" {
   description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with BC Services Card for PRIME."
 }
 
-resource "keycloak_saml_client_scope" "moh_idp_openid_client_scope" {
+resource "keycloak_saml_client_scope" "moh_idp_saml_client_scope" {
   realm_id    = "moh_applications"
   name        = "moh_idp-saml"
   description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with Keycloak."
+}
+
+resource "keycloak_saml_client_scope" "yukon_aad_saml_client_scope" {
+  realm_id    = "moh_applications"
+  name        = "yukon_aad-saml"
+  description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with Yukon MFA."
 }

--- a/keycloak-test/realms/moh_applications/clientScopes.tf
+++ b/keycloak-test/realms/moh_applications/clientScopes.tf
@@ -70,7 +70,7 @@ resource "keycloak_openid_client_scope" "moh_idp_openid_client_scope" {
   description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with Keycloak."
 }
 
-resource "keycloak_openid_client_scope" "yukon_aad_client_scope" {
+resource "keycloak_openid_client_scope" "yukon_aad_openid_client_scope" {
   realm_id    = "moh_applications"
   name        = "yukon_aad"
   description = "Assign this scope to an OIDC client using IDP restriction module to allow logging in with Yukon MFA."

--- a/keycloak-test/realms/moh_applications/clientScopes.tf
+++ b/keycloak-test/realms/moh_applications/clientScopes.tf
@@ -142,7 +142,7 @@ resource "keycloak_saml_client_scope" "bcsc_prime_saml_client_scope" {
   description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with BC Services Card for PRIME."
 }
 
-resource "keycloak_saml_client_scope" "moh_idp_openid_client_scope" {
+resource "keycloak_saml_client_scope" "moh_idp_saml_client_scope" {
   realm_id    = "moh_applications"
   name        = "moh_idp-saml"
   description = "Assign this scope to a SAML client using IDP restriction module to allow logging in with Keycloak."

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -65,7 +65,9 @@ module "EMCOD" {
   source = "./clients/emcod"
 }
 module "FLORIZEL" {
-  source = "./clients/florizel"
+  source                       = "./clients/florizel"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
+
 }
 module "FLORIZEL-TRAINING" {
   source = "./clients/florizel-training"
@@ -77,7 +79,9 @@ module "FORMS" {
   source = "./clients/forms"
 }
 module "GENESYS" {
-  source = "./clients/genesys"
+  source                       = "./clients/genesys"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
+
 }
 module "GENESYS-TRAINING" {
   source = "./clients/genesys-training"

--- a/keycloak-test/realms/moh_applications/clients/florizel/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/florizel/main.tf
@@ -17,7 +17,6 @@ resource "keycloak_saml_client" "CLIENT" {
   force_name_id_format      = true
   name_id_format            = "persistent"
   full_scope_allowed        = false
-  login_theme               = "moh-app-realm"
 
   valid_redirect_uris = [
     "https://hlbc-test.fonemedhms.com/*",
@@ -26,6 +25,12 @@ resource "keycloak_saml_client" "CLIENT" {
 
   assertion_consumer_redirect_url = "https://hlbc-test.fonemedhms.com/adminusers/auth/saml/callback"
   assertion_consumer_post_url     = "https://hlbc-test.fonemedhms.com/adminusers/auth/saml/callback"
+
+  authentication_flow_binding_overrides {
+    #browser-idp-restriction flow
+    browser_id = var.browser_idp_restriction_flow
+  }
+  login_theme = "moh-app-realm-idp-restriction"
 }
 
 
@@ -92,4 +97,13 @@ resource "keycloak_role" "HealthlinkBC_NurseLead" {
   client_id   = keycloak_saml_client.CLIENT.id
   name        = "HealthlinkBC_NurseLead"
   description = "Equivalent of Clinical Manager"
+}
+
+resource "keycloak_saml_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_saml_client.CLIENT.realm_id
+  client_id = keycloak_saml_client.CLIENT.id
+  default_scopes = [
+    "idir_aad-saml",
+    "moh_idp-saml"
+  ]
 }

--- a/keycloak-test/realms/moh_applications/clients/florizel/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/florizel/variables.tf
@@ -1,0 +1,1 @@
+variable "browser_idp_restriction_flow" {}

--- a/keycloak-test/realms/moh_applications/clients/genesys/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/genesys/main.tf
@@ -17,7 +17,6 @@ resource "keycloak_saml_client" "CLIENT" {
   force_name_id_format      = false
   name_id_format            = "persistent"
   full_scope_allowed        = false
-  login_theme               = "idir_aad-phsa-bcprovider"
 
   valid_redirect_uris = [
     "https://login.cac1.pure.cloud/*",
@@ -29,6 +28,12 @@ resource "keycloak_saml_client" "CLIENT" {
   assertion_consumer_post_url         = "https://login.cac1.pure.cloud/saml"
   logout_service_redirect_binding_url = "https://login.cac1.pure.cloud/saml/logout"
   logout_service_post_binding_url     = "https://login.cac1.pure.cloud/saml/logout"
+
+  authentication_flow_binding_overrides {
+    #browser-idp-restriction flow
+    browser_id = var.browser_idp_restriction_flow
+  }
+  login_theme = "moh-app-realm-idp-restriction"
 }
 
 resource "keycloak_generic_client_protocol_mapper" "saml_hardcoded_attribute_mapper" {
@@ -53,4 +58,14 @@ resource "keycloak_saml_user_attribute_protocol_mapper" "saml_user_attribute_map
   saml_attribute_name        = "email"
   friendly_name              = "email"
   saml_attribute_name_format = "Basic"
+}
+
+resource "keycloak_saml_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_saml_client.CLIENT.realm_id
+  client_id = keycloak_saml_client.CLIENT.id
+  default_scopes = [
+    "idir_aad-saml",
+    "bcprovider_aad-saml",
+    "phsa_aad-saml"
+  ]
 }

--- a/keycloak-test/realms/moh_applications/clients/genesys/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/genesys/variables.tf
@@ -1,0 +1,1 @@
+variable "browser_idp_restriction_flow" {}


### PR DESCRIPTION
### Changes being made

Setting up IDP restriction module for Genesys and Florizel test clients.

### Context

Enforcing IDIR MFA in test realm

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 