### PR TITLE
removing phsa windows account mapper from prod hspp/prp

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
@@ -227,19 +227,3 @@ module "client-roles" {
     }
   }
 }
-
-resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "preferred_username"
-  protocol        = "openid-connect"
-  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
-  config = {
-    "userinfo.token.claim" : "true",
-    "user.attribute" : "phsa_windowsaccountname",
-    "id.token.claim" : "true",
-    "access.token.claim" : "true",
-    "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
-  }
-}

--- a/keycloak-prod/realms/moh_applications/clients/prp-web/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/prp-web/main.tf
@@ -116,18 +116,3 @@ module "scope-mappings" {
     "LICENCE-STATUS/PHARM"                = var.LICENCE-STATUS.ROLES["PHARM"].id
   }
 }
-resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
-  realm_id        = keycloak_openid_client.CLIENT.realm_id
-  client_id       = keycloak_openid_client.CLIENT.id
-  name            = "preferred_username"
-  protocol        = "openid-connect"
-  protocol_mapper = "oidc-override-usermodel-attribute-mapper"
-  config = {
-    "userinfo.token.claim" : "true",
-    "user.attribute" : "phsa_windowsaccountname",
-    "id.token.claim" : "true",
-    "access.token.claim" : "true",
-    "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
-  }
-}


### PR DESCRIPTION
### Changes being made

Removing old phsa windows account mapper from prod for HSPP and PRP-WEB. *Did not exist for HSIAR.

### Context

Requested by client.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]

