### PR TITLE
Idp restriction module test

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -497,7 +497,8 @@ module "TBCM" {
   source = "./clients/tbcm"
 }
 module "TPL" {
-  source = "./clients/tpl"
+  source                       = "./clients/tpl"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
 }
 module "USAM" {
   source = "./clients/usam"

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -49,11 +49,13 @@ module "EACL_STG" {
   source = "./clients/eacl_stg"
 }
 module "EDRD" {
-  source = "./clients/edrd"
+  source                       = "./clients/edrd"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
 }
 module "EDRD-PORTAL" {
-  source         = "./clients/edrd-portal"
-  LICENCE-STATUS = module.LICENCE-STATUS
+  source                       = "./clients/edrd-portal"
+  LICENCE-STATUS               = module.LICENCE-STATUS
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
 }
 module "EHPR" {
   source = "./clients/ehpr"

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -475,7 +475,8 @@ module "SA-HIBC-SERVICE-BC-PORTAL" {
 
 }
 module "SA-SFDC" {
-  source = "./clients/sa-sfdc"
+  source                       = "./clients/sa-sfdc"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
 }
 module "SAT-EFORMS_QA" {
   source = "./clients/sat-eforms_qa"

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -206,7 +206,9 @@ module "LRA-TEST" {
   LICENCE-STATUS = module.LICENCE-STATUS
 }
 module "MAID" {
-  source = "./clients/maid"
+  source                       = "./clients/maid"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
+
 }
 module "METASPACE" {
   source = "./clients/metaspace"

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -470,7 +470,9 @@ module "SA-DBAAC-PORTAL" {
 
 }
 module "SA-HIBC-SERVICE-BC-PORTAL" {
-  source = "./clients/sa-hibc-service-bc-portal"
+  source                       = "./clients/sa-hibc-service-bc-portal"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
+
 }
 module "SA-SFDC" {
   source = "./clients/sa-sfdc"

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -168,7 +168,8 @@ module "HSPP" {
   LICENCE-STATUS = module.LICENCE-STATUS
 }
 module "ICY" {
-  source = "./clients/icy"
+  source                       = "./clients/icy"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
 }
 module "IEN" {
   source = "./clients/ien"

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -465,7 +465,9 @@ module "SAT-EFORMS" {
   source = "./clients/sat-eforms"
 }
 module "SA-DBAAC-PORTAL" {
-  source = "./clients/sa-dbaac-portal"
+  source                       = "./clients/sa-dbaac-portal"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
+
 }
 module "SA-HIBC-SERVICE-BC-PORTAL" {
   source = "./clients/sa-hibc-service-bc-portal"

--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -5,7 +5,8 @@ module "realm-management" {
   source = "../../../modules/realm-management"
 }
 module "ALR" {
-  source = "./clients/alr"
+  source                       = "./clients/alr"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
 }
 module "BCER-CP" {
   source = "./clients/bcer-cp"

--- a/keycloak-test/realms/moh_applications/clients/alr/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/alr/main.tf
@@ -35,6 +35,11 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
   web_origins = [
   ]
+  authentication_flow_binding_overrides {
+    #browser-idp-restriction flow
+    browser_id = var.browser_idp_restriction_flow
+  }
+  login_theme = "moh-app-realm-idp-restriction"
 }
 
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
@@ -44,7 +49,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "idir_aad"
   ]
 }
 

--- a/keycloak-test/realms/moh_applications/clients/alr/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/alr/variables.tf
@@ -1,0 +1,1 @@
+variable "browser_idp_restriction_flow" {}

--- a/keycloak-test/realms/moh_applications/clients/edrd-portal/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/edrd-portal/main.tf
@@ -27,6 +27,11 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
   web_origins = [
   ]
+  authentication_flow_binding_overrides {
+    #browser-idp-restriction flow
+    browser_id = var.browser_idp_restriction_flow
+  }
+  login_theme = "moh-app-realm-idp-restriction"
 }
 
 module "client-roles" {
@@ -99,4 +104,12 @@ module "scope-mappings" {
     "LICENCE-STATUS/MD"           = var.LICENCE-STATUS.ROLES["MD"].id
     "LICENCE-STATUS/RNP"          = var.LICENCE-STATUS.ROLES["RNP"].id
   }
+}
+
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "bcprovider_aad"
+  ]
 }

--- a/keycloak-test/realms/moh_applications/clients/edrd-portal/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/edrd-portal/variables.tf
@@ -1,1 +1,2 @@
 variable "LICENCE-STATUS" {}
+variable "browser_idp_restriction_flow" {}

--- a/keycloak-test/realms/moh_applications/clients/edrd/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/edrd/main.tf
@@ -28,6 +28,11 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
   web_origins = [
   ]
+  authentication_flow_binding_overrides {
+    #browser-idp-restriction flow
+    browser_id = var.browser_idp_restriction_flow
+  }
+  login_theme = "moh-app-realm-idp-restriction"
 }
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
@@ -59,4 +64,13 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   multivalued                 = true
   name                        = "client roles"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "idir_aad",
+    "phsa"
+  ]
 }

--- a/keycloak-test/realms/moh_applications/clients/edrd/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/edrd/variables.tf
@@ -1,0 +1,1 @@
+variable "browser_idp_restriction_flow" {}

--- a/keycloak-test/realms/moh_applications/clients/icy/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/icy/main.tf
@@ -28,6 +28,11 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
   web_origins = [
   ]
+  authentication_flow_binding_overrides {
+    #browser-idp-restriction flow
+    browser_id = var.browser_idp_restriction_flow
+  }
+  login_theme = "moh-app-realm-idp-restriction"
 }
 
 module "client-roles" {
@@ -424,4 +429,13 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "client_role_mapper"
   multivalued                 = true
   name                        = "client roles"
   realm_id                    = keycloak_openid_client.CLIENT.realm_id
+}
+
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "idir_aad",
+    "bceid_business"
+  ]
 }

--- a/keycloak-test/realms/moh_applications/clients/icy/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/icy/variables.tf
@@ -1,0 +1,1 @@
+variable "browser_idp_restriction_flow" {}

--- a/keycloak-test/realms/moh_applications/clients/maid/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/maid/main.tf
@@ -30,6 +30,11 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
   web_origins = [
   ]
+  authentication_flow_binding_overrides {
+    #browser-idp-restriction flow
+    browser_id = var.browser_idp_restriction_flow
+  }
+  login_theme = "moh-app-realm-idp-restriction"
 }
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
@@ -69,6 +74,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "idir_aad"
   ]
 }

--- a/keycloak-test/realms/moh_applications/clients/maid/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/maid/variables.tf
@@ -1,0 +1,1 @@
+variable "browser_idp_restriction_flow" {}

--- a/keycloak-test/realms/moh_applications/clients/sa-dbaac-portal/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sa-dbaac-portal/main.tf
@@ -22,6 +22,8 @@ module "payara-client" {
     "https://bchealth--satdev1.sandbox.my.salesforce.com/*",
     "https://bchealth--satdev1.sandbox.my.site.com/*",
   ]
+  authentication_flow_binding_override_browser_id = var.browser_idp_restriction_flow
+  login_theme                                     = "moh-app-realm-idp-restriction"
 }
 resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   add_to_id_token  = true
@@ -31,4 +33,12 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   name             = "IDP"
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
+}
+
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "idir_aad"
+  ]
 }

--- a/keycloak-test/realms/moh_applications/clients/sa-dbaac-portal/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sa-dbaac-portal/main.tf
@@ -36,8 +36,8 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
 }
 
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
-  realm_id  = keycloak_openid_client.CLIENT.realm_id
-  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = module.payara-client.CLIENT.realm_id
+  client_id = module.payara-client.CLIENT.id
   default_scopes = [
     "idir_aad"
   ]

--- a/keycloak-test/realms/moh_applications/clients/sa-dbaac-portal/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/sa-dbaac-portal/variables.tf
@@ -1,0 +1,1 @@
+variable "browser_idp_restriction_flow" {}

--- a/keycloak-test/realms/moh_applications/clients/sa-hibc-service-bc-portal/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sa-hibc-service-bc-portal/main.tf
@@ -27,6 +27,8 @@ module "payara-client" {
     "https://bchealth--satdev1.sandbox.my.salesforce.com/*",
     "https://bchealth--satdev1.sandbox.my.site.com/*",
   ]
+  authentication_flow_binding_override_browser_id = var.browser_idp_restriction_flow
+  login_theme                                     = "moh-app-realm-idp-restriction"
 }
 resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   add_to_id_token  = true
@@ -36,4 +38,12 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   name             = "IDP"
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
+}
+
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "idir_aad"
+  ]
 }

--- a/keycloak-test/realms/moh_applications/clients/sa-hibc-service-bc-portal/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sa-hibc-service-bc-portal/main.tf
@@ -41,8 +41,8 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
 }
 
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
-  realm_id  = keycloak_openid_client.CLIENT.realm_id
-  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = module.payara-client.CLIENT.realm_id
+  client_id = module.payara-client.CLIENT.id
   default_scopes = [
     "idir_aad"
   ]

--- a/keycloak-test/realms/moh_applications/clients/sa-hibc-service-bc-portal/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/sa-hibc-service-bc-portal/variables.tf
@@ -1,0 +1,1 @@
+variable "browser_idp_restriction_flow" {}

--- a/keycloak-test/realms/moh_applications/clients/sa-sfdc/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sa-sfdc/main.tf
@@ -33,6 +33,8 @@ module "payara-client" {
     "https://bchealth--satdev1.sandbox.my.salesforce.com/*",
     "https://bchealth--edrddev2.sandbox.my.salesforce.com/"
   ]
+  authentication_flow_binding_override_browser_id = var.browser_idp_restriction_flow
+  login_theme                                     = "moh-app-realm-idp-restriction"
 }
 resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   add_to_id_token  = true
@@ -42,4 +44,12 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
   name             = "IDP"
   realm_id         = module.payara-client.CLIENT.realm_id
   session_note     = "identity_provider"
+}
+
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "idir_aad"
+  ]
 }

--- a/keycloak-test/realms/moh_applications/clients/sa-sfdc/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sa-sfdc/main.tf
@@ -47,8 +47,8 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "IDP" {
 }
 
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
-  realm_id  = keycloak_openid_client.CLIENT.realm_id
-  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = module.payara-client.CLIENT.realm_id
+  client_id = module.payara-client.CLIENT.id
   default_scopes = [
     "idir_aad"
   ]

--- a/keycloak-test/realms/moh_applications/clients/sa-sfdc/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/sa-sfdc/variables.tf
@@ -1,0 +1,1 @@
+variable "browser_idp_restriction_flow" {}

--- a/keycloak-test/realms/moh_applications/clients/tpl/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/tpl/main.tf
@@ -28,6 +28,11 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
   web_origins = [
   ]
+  authentication_flow_binding_overrides {
+    #browser-idp-restriction flow
+    browser_id = var.browser_idp_restriction_flow
+  }
+  login_theme = "moh-app-realm-idp-restriction"
 }
 module "client-roles" {
   source    = "../../../../../modules/client-roles"
@@ -64,6 +69,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "idir_aad"
   ]
 }

--- a/keycloak-test/realms/moh_applications/clients/tpl/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/tpl/variables.tf
@@ -1,0 +1,1 @@
+variable "browser_idp_restriction_flow" {}


### PR DESCRIPTION
### Changes being made

Enforcing IDIR MFA for CGI-Salesforce applications in Keycloak Test. Omitted PRIMARY-CARE for now. 

### Context

Enforcing by configuring the idp restriction module. Idps in use were deducted based on the CMDB and visiting applications in Keycloak Tes environment.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 