### PR TITLE
adding new roles to hspp test and prod

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
@@ -225,7 +225,7 @@ module "client-roles" {
     "HSPP_Restricted_LTC_VIHA" = {
       "name" = "HSPP_Restricted_LTC_VIHA"
     },
-       "HSPP_ReportProgram_Operations" = {
+    "HSPP_ReportProgram_Operations" = {
       "name" = "HSPP_ReportProgram_Operations"
     },
     "HSPP_ReportSection_Operations" = {

--- a/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hspp/main.tf
@@ -224,6 +224,24 @@ module "client-roles" {
     },
     "HSPP_Restricted_LTC_VIHA" = {
       "name" = "HSPP_Restricted_LTC_VIHA"
+    },
+       "HSPP_ReportProgram_Operations" = {
+      "name" = "HSPP_ReportProgram_Operations"
+    },
+    "HSPP_ReportSection_Operations" = {
+      "name" = "HSPP_ReportSection_Operations"
+    },
+    "HSPP_Operations_PPM_PPD" = {
+      "name" = "HSPP_Operations_PPM_PPD"
+    },
+    "HSPP_Operations_CCS_PA" = {
+      "name" = "HSPP_Operations_CCA_PA"
+    }
+    "HSPP_Operations_CCS_SDA" = {
+      "name" = "HSPP_Operations_CCS_SDA"
+    }
+    "HSPP_Operations_PAW_HA" = {
+      "name" = "HSPP_Operations_PAW_HA"
     }
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/hspp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hspp/main.tf
@@ -240,6 +240,24 @@ module "client-roles" {
     },
     "HSPP_Restricted_LTC_VIHA" = {
       "name" = "HSPP_Restricted_LTC_VIHA"
+    },
+    "HSPP_ReportProgram_Operations" = {
+      "name" = "HSPP_ReportProgram_Operations"
+    },
+    "HSPP_ReportSection_Operations" = {
+      "name" = "HSPP_ReportSection_Operations"
+    },
+    "HSPP_Operations_PPM_PPD" = {
+      "name" = "HSPP_Operations_PPM_PPD"
+    },
+    "HSPP_Operations_CCS_PA" = {
+      "name" = "HSPP_Operations_CCA_PA"
+    }
+    "HSPP_Operations_CCS_SDA" = {
+      "name" = "HSPP_Operations_CCS_SDA"
+    }
+    "HSPP_Operations_PAW_HA" = {
+      "name" = "HSPP_Operations_PAW_HA"
     }
   }
 }


### PR DESCRIPTION
### Changes being made

Adding 6 new roles to HSPP in test and prod environment.
1.	HSPP_ReportProgram_Operations 
2.	HSPP_ReportSection_Operations 
3.	HSPP_Operations_PPM_PPD 
4.	HSPP_Operations_CCS_PA 
5.	HSPP_Operations_CCS_SDA 
6.	HSPP_Operations_PAW_HA 


### Context

Changes requested by client.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
