### PR TITLE
update introspection token claims

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/bcer-cp/main.tf
@@ -57,6 +57,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-dev/realms/moh_applications/clients/connect/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/connect/main.tf
@@ -89,6 +89,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-dev/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/forms/main.tf
@@ -88,6 +88,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-dev/realms/moh_applications/clients/hcimweb/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/hcimweb/main.tf
@@ -88,6 +88,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-dev/realms/moh_applications/clients/moh-servicenow/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/moh-servicenow/main.tf
@@ -54,6 +54,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-dev/realms/moh_applications/clients/pidp-webapp/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/pidp-webapp/main.tf
@@ -388,7 +388,8 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }
 


### PR DESCRIPTION
### Changes being made

Updating custom mappers on DEV to include the introspection.toke.claim value.

### Context

Introspection token endpoint is not available in Keycloak, so we do not need to make those mappers available.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.