### PR TITLE
upgrade oidc defaults

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/alr/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/alr/main.tf
@@ -50,7 +50,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "profile",
     "roles",
     "web-origins",
-    "idir_aad"
+    "idir_aad",
+    "basic"
   ]
 }
 

--- a/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/bcer-cp/main.tf
@@ -62,6 +62,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/connect/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/connect/main.tf
@@ -56,7 +56,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 
@@ -83,6 +84,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/dht-dev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/dht-dev/main.tf
@@ -64,6 +64,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/edrd-portal/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/edrd-portal/main.tf
@@ -114,6 +114,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   default_scopes = [
     "bcprovider_aad",
     "profile",
-    "email"
+    "email",
+    "basic"
   ]
 }

--- a/keycloak-test/realms/moh_applications/clients/edrd/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/edrd/main.tf
@@ -75,6 +75,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "idir_aad",
     "phsa",
     "profile",
-    "email"
+    "email",
+    "basic"
   ]
 }

--- a/keycloak-test/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/forms/main.tf
@@ -56,7 +56,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 
@@ -83,6 +84,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/gis/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/gis/main.tf
@@ -38,6 +38,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/hamis/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hamis/main.tf
@@ -112,6 +112,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/hcap-fe/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcap-fe/main.tf
@@ -30,7 +30,8 @@ resource "keycloak_openid_client" "CLIENT" {
     "https://www.hcapemployers.test.freshworks.club/*",
     "https://hcapparticipants.test.freshworks.club/*",
     "http://hcapparticipants.localhost:4000/*",
-    "http://hcapemployers.localhost:4000/*"
+    "http://hcapemployers.localhost:4000/*",
+    "http://localhost:8080/*"
   ]
   web_origins = [
     "*",

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hiat1/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hiat1/main.tf
@@ -83,6 +83,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hiat2/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hiat2/main.tf
@@ -83,6 +83,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hiat3/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hiat3/main.tf
@@ -83,6 +83,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_hs1/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_hs1/main.tf
@@ -83,6 +83,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/hcimweb_huat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcimweb_huat/main.tf
@@ -84,6 +84,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/hdpbc/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hdpbc/main.tf
@@ -45,7 +45,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 

--- a/keycloak-test/realms/moh_applications/clients/hscis/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hscis/main.tf
@@ -99,6 +99,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/icy/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/icy/main.tf
@@ -438,6 +438,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "idir_aad",
     "bceid_business",
     "profile",
-    "email"
+    "email",
+    "basic"
   ]
 }

--- a/keycloak-test/realms/moh_applications/clients/ivf-portal/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/ivf-portal/main.tf
@@ -78,7 +78,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "bcprovider_aad",
     "idir_aad",
     "profile",
-    "email"
+    "email",
+    "basic"
   ]
 }
 

--- a/keycloak-test/realms/moh_applications/clients/lra-dev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/lra-dev/main.tf
@@ -65,6 +65,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/maid/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/maid/main.tf
@@ -75,6 +75,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "profile",
     "roles",
     "web-origins",
-    "idir_aad"
+    "idir_aad",
+    "basic"
   ]
 }

--- a/keycloak-test/realms/moh_applications/clients/metaspace/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/metaspace/main.tf
@@ -84,7 +84,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 

--- a/keycloak-test/realms/moh_applications/clients/miwt_stg/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/miwt_stg/main.tf
@@ -64,6 +64,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/moh-servicenow/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/moh-servicenow/main.tf
@@ -57,6 +57,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/pidp-webapp/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/pidp-webapp/main.tf
@@ -85,6 +85,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/plr_conf/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_conf/main.tf
@@ -43,7 +43,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "profile",
     "email",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 resource "keycloak_openid_user_attribute_protocol_mapper" "org_details" {

--- a/keycloak-test/realms/moh_applications/clients/plr_flvr/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_flvr/main.tf
@@ -42,7 +42,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 resource "keycloak_openid_user_attribute_protocol_mapper" "org_details" {

--- a/keycloak-test/realms/moh_applications/clients/plr_iat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_iat/main.tf
@@ -42,7 +42,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 resource "keycloak_openid_user_attribute_protocol_mapper" "org_details" {
@@ -87,6 +88,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/plr_rev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_rev/main.tf
@@ -42,7 +42,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 resource "keycloak_openid_user_attribute_protocol_mapper" "org_details" {
@@ -86,6 +87,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/plr_sit/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_sit/main.tf
@@ -43,7 +43,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 resource "keycloak_openid_user_attribute_protocol_mapper" "org_details" {

--- a/keycloak-test/realms/moh_applications/clients/plr_stg/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_stg/main.tf
@@ -43,7 +43,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 resource "keycloak_openid_user_attribute_protocol_mapper" "org_details" {

--- a/keycloak-test/realms/moh_applications/clients/plr_uat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/plr_uat/main.tf
@@ -42,7 +42,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 resource "keycloak_openid_user_attribute_protocol_mapper" "org_details" {

--- a/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/primary-care/main.tf
@@ -148,7 +148,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 

--- a/keycloak-test/realms/moh_applications/clients/sa-dbaac-portal/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sa-dbaac-portal/main.tf
@@ -44,6 +44,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "idir_aad",
     "profile",
     "email",
-    "roles"
+    "roles",
+    "basic"
   ]
 }

--- a/keycloak-test/realms/moh_applications/clients/sa-hibc-service-bc-portal/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sa-hibc-service-bc-portal/main.tf
@@ -50,6 +50,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "idir_aad",
     "profile",
     "email",
-    "roles"
+    "roles",
+    "basic"
   ]
 }

--- a/keycloak-test/realms/moh_applications/clients/sa-sfdc/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sa-sfdc/main.tf
@@ -67,6 +67,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "idir_aad",
     "profile",
     "email",
-    "roles"
+    "roles",
+    "basic"
   ]
 }

--- a/keycloak-test/realms/moh_applications/clients/sat-eforms/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/sat-eforms/main.tf
@@ -103,6 +103,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/tbcm/main.tf
@@ -65,6 +65,7 @@ resource "keycloak_generic_client_protocol_mapper" "phsa_windowsaccountname" {
     "id.token.claim" : "true",
     "access.token.claim" : "true",
     "claim.name" : "preferred_username",
-    "jsonType.label" : "String"
+    "jsonType.label" : "String",
+    "introspection.token.claim" = "false"
   }
 }

--- a/keycloak-test/realms/moh_applications/clients/tpl/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/tpl/main.tf
@@ -70,6 +70,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "profile",
     "roles",
     "web-origins",
-    "idir_aad"
+    "idir_aad",
+    "basic"
   ]
 }

--- a/keycloak-test/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management/main.tf
@@ -60,7 +60,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 module "scope-mappings" {


### PR DESCRIPTION
### Changes being made

Add redirect URL for HCAP. 
For various clients: 
- Add "basic" scope as default.
-  Remove custom mapper from introspection token endpoint response.

### Context

Changes necessary due to Keycloak version upgrade.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden.