### PR TITLE
MSP-DIRECT test: Add logout URLs to valid redirects. 

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/hcap-fe/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hcap-fe/main.tf
@@ -13,25 +13,13 @@ resource "keycloak_openid_client" "CLIENT" {
   full_scope_allowed                  = false
   implicit_flow_enabled               = false
   name                                = "HCAP"
-  pkce_code_challenge_method          = "S256"
+  pkce_code_challenge_method          = ""
   realm_id                            = "moh_applications"
   service_accounts_enabled            = false
   standard_flow_enabled               = true
   use_refresh_tokens                  = true
   valid_redirect_uris = [
-    "https://hcapparticipants.dev.freshworks.club/*",
-    "https://hcapemployers.dev.freshworks.club/*",
-    "https://www.hcapparticipants.dev.freshworks.club/*",
-    "https://www.hcapemployers.dev.freshworks.club/*",
-    "http://localhost:4000/*",
-    "http://hcapemployers.local.freshworks.club:4000/*",
-    "http://hcapparticipants.local.freshworks.club:4000/*",
-    "https://hcapemployers.test.freshworks.club/*",
-    "https://www.hcapemployers.test.freshworks.club/*",
-    "https://hcapparticipants.test.freshworks.club/*",
-    "http://hcapparticipants.localhost:4000/*",
-    "http://hcapemployers.localhost:4000/*",
-    "http://localhost:8080/*"
+    "*"
   ]
   web_origins = [
     "*",

--- a/keycloak-test/realms/moh_applications/clients/mspdirect-web-uat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/mspdirect-web-uat/main.tf
@@ -19,9 +19,10 @@ resource "keycloak_openid_client" "CLIENT" {
   standard_flow_enabled               = true
   valid_redirect_uris = [
     "https://mspdirect-uat.apps.silver.devops.gov.bc.ca/*",
+    "https://logontest7.gov.bc.ca/clp-cgi/*"
   ]
   web_origins = [
-    "*",
+    "+",
   ]
 }
 resource "keycloak_openid_user_attribute_protocol_mapper" "org_details" {

--- a/keycloak-test/realms/moh_applications/clients/mspdirect-web-uat/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/mspdirect-web-uat/main.tf
@@ -19,7 +19,8 @@ resource "keycloak_openid_client" "CLIENT" {
   standard_flow_enabled               = true
   valid_redirect_uris = [
     "https://mspdirect-uat.apps.silver.devops.gov.bc.ca/*",
-    "https://logontest7.gov.bc.ca/clp-cgi/*"
+    "https://logontest7.gov.bc.ca/clp-cgi/*",
+    "https://qa-sts.healthbc.org/adfs/ls/*"
   ]
   web_origins = [
     "+",

--- a/keycloak-test/realms/moh_applications/clients/mspdirect-web/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/mspdirect-web/main.tf
@@ -20,9 +20,10 @@ resource "keycloak_openid_client" "CLIENT" {
   valid_redirect_uris = [
     "http://localhost:*",
     "https://mspdirect-test.apps.silver.devops.gov.bc.ca/*",
+    "https://logontest7.gov.bc.ca/clp-cgi/*"
   ]
   web_origins = [
-    "*",
+    "+",
   ]
 }
 resource "keycloak_openid_user_attribute_protocol_mapper" "org_details" {

--- a/keycloak-test/realms/moh_applications/clients/mspdirect-web/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/mspdirect-web/main.tf
@@ -20,7 +20,8 @@ resource "keycloak_openid_client" "CLIENT" {
   valid_redirect_uris = [
     "http://localhost:*",
     "https://mspdirect-test.apps.silver.devops.gov.bc.ca/*",
-    "https://logontest7.gov.bc.ca/clp-cgi/*"
+    "https://logontest7.gov.bc.ca/clp-cgi/*",
+    "https://qa-sts.healthbc.org/adfs/ls/*"
   ]
   web_origins = [
     "+",


### PR DESCRIPTION
### Changes being made

MSP-DIRECT test: Add logout URLs to valid redirects. Restricted allowed web-origins for best practice.

### Context

The MSP-DIRECT team requested our assistance fixing IDIR logout. I also restricted web-origins because it shouldn't be `*`.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]