### PR TITLE
DEV/TEST: Adding default scopes to PRIME clients.

### DIFF
--- a/keycloak-dev/realms/moh_applications/clients/prime-application-dev/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/prime-application-dev/main.tf
@@ -26,6 +26,19 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "acr",
+    "address",
+    "email",
+    "profile",
+    "roles",
+    "web-origins",
+  ]
+}
+
 resource "keycloak_openid_user_attribute_protocol_mapper" "birthdate" {
   claim_name     = "birthdate"
   client_id      = keycloak_openid_client.CLIENT.id

--- a/keycloak-dev/realms/moh_applications/clients/prime-application-local/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/prime-application-local/main.tf
@@ -26,6 +26,19 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "acr",
+    "address",
+    "email",
+    "profile",
+    "roles",
+    "web-origins",
+  ]
+}
+
 resource "keycloak_openid_audience_protocol_mapper" "prime-web-api" {
   add_to_id_token          = false
   client_id                = keycloak_openid_client.CLIENT.id

--- a/keycloak-dev/realms/moh_applications/clients/prime-application-test/main.tf
+++ b/keycloak-dev/realms/moh_applications/clients/prime-application-test/main.tf
@@ -26,6 +26,19 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "acr",
+    "address",
+    "email",
+    "profile",
+    "roles",
+    "web-origins",
+  ]
+}
+
 resource "keycloak_openid_audience_protocol_mapper" "prime-web-api" {
   add_to_id_token          = false
   client_id                = keycloak_openid_client.CLIENT.id

--- a/keycloak-prod/realms/moh_applications/clients/terraform/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/terraform/main.tf
@@ -8,7 +8,7 @@ resource "keycloak_openid_client" "CLIENT" {
   consent_required                    = false
   description                         = ""
   direct_access_grants_enabled        = false
-  enabled                             = true
+  enabled                             = false
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
   implicit_flow_enabled               = false

--- a/keycloak-test/realms/moh_applications/clients/prime-application-dev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prime-application-dev/main.tf
@@ -26,6 +26,19 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "acr",
+    "address",
+    "email",
+    "profile",
+    "roles",
+    "web-origins",
+  ]
+}
+
 resource "keycloak_openid_user_attribute_protocol_mapper" "birthdate" {
   claim_name     = "birthdate"
   client_id      = keycloak_openid_client.CLIENT.id

--- a/keycloak-test/realms/moh_applications/clients/prime-application-local/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prime-application-local/main.tf
@@ -26,6 +26,19 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "acr",
+    "address",
+    "email",
+    "profile",
+    "roles",
+    "web-origins",
+  ]
+}
+
 resource "keycloak_openid_audience_protocol_mapper" "prime-web-api" {
   add_to_id_token          = false
   client_id                = keycloak_openid_client.CLIENT.id

--- a/keycloak-test/realms/moh_applications/clients/prime-application-test/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prime-application-test/main.tf
@@ -26,6 +26,19 @@ resource "keycloak_openid_client" "CLIENT" {
   ]
 }
 
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  default_scopes = [
+    "acr",
+    "address",
+    "email",
+    "profile",
+    "roles",
+    "web-origins",
+  ]
+}
+
 resource "keycloak_openid_audience_protocol_mapper" "prime-web-api" {
   add_to_id_token          = false
   client_id                = keycloak_openid_client.CLIENT.id


### PR DESCRIPTION
### Changes being made

DEV/TEST: Adding default scopes to PRIME client address scope default.

### Context

Fix missing address scope setting in PRIME Terraform config

Adds the address scope to the client default scopes in PRIME’s Terraform config to match the manual changes already applied in DEV, TEST, and PROD. This ensures consistency and avoids future issues when reusing the configuration.

### Quality Check
- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.