### PR TITLE
create ivf-clinic portal

### DIFF
--- a/keycloak-test/realms/moh_applications/clients.tf
+++ b/keycloak-test/realms/moh_applications/clients.tf
@@ -174,6 +174,11 @@ module "ICY" {
 module "IEN" {
   source = "./clients/ien"
 }
+module "IVF-CLINIC-PORTAL" {
+  source                       = "./clients/ivf-clinic-portal"
+  browser_idp_restriction_flow = local.browser_idp_restriction_flow
+  LICENCE-STATUS               = module.LICENCE-STATUS
+}
 module "IVF-PORTAL" {
   source                       = "./clients/ivf-portal"
   browser_idp_restriction_flow = local.browser_idp_restriction_flow

--- a/keycloak-test/realms/moh_applications/clients/ivf-clinic-portal/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/ivf-clinic-portal/main.tf
@@ -4,24 +4,24 @@ resource "keycloak_openid_client" "CLIENT" {
   backchannel_logout_session_required = true
   base_url                            = ""
   client_authenticator_type           = "client-secret"
-  client_id                           = "IVF-PORTAL"
+  client_id                           = "IVF-CLINIC-PORTAL"
   consent_required                    = false
-  description                         = "IVF Portal is an application management system to effectively handle IVF application volumes"
+  description                         = "IVF Portal is an application management system to effectively handle IVF application volumes. This client is dedicated for clinic personel."
   direct_access_grants_enabled        = false
   enabled                             = true
   frontchannel_logout_enabled         = false
   full_scope_allowed                  = false
   implicit_flow_enabled               = false
-  name                                = "IVF Portal"
+  name                                = "IVF Clinic Portal"
   pkce_code_challenge_method          = ""
   realm_id                            = "moh_applications"
   service_accounts_enabled            = false
   standard_flow_enabled               = true
   use_refresh_tokens                  = false
   valid_redirect_uris = [
-    "https://bcministryofhealth-ivfportal--ivfdev.sandbox.my.salesforce.com/*",
-    "https://bcministryofhealth-ivfportal--ivfqa.sandbox.my.salesforce.com/*",
-    "https://bcministryofhealth-ivfportal--ivfuat.sandbox.my.salesforce.com/*"
+    "https://bcministryofhealth-ivfportal--ivfdev.sandbox.my.site.com/*",
+    "https://bcministryofhealth-ivfportal--ivfqa.sandbox.my.site.com/*",
+    "https://bcministryofhealth-ivfportal--ivfuat.sandbox.my.site.com/*"
   ]
   web_origins = [
   ]
@@ -61,10 +61,10 @@ module "client-roles" {
   client_id = keycloak_openid_client.CLIENT.id
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   roles = {
-    "bdsb-admin" = {
-      "name"        = "bdsb-admin"
+    "clinic-admin" = {
+      "name"        = "clinic-admin"
       "description" = ""
-    },
+    }
   }
 }
 

--- a/keycloak-test/realms/moh_applications/clients/ivf-clinic-portal/outputs.tf
+++ b/keycloak-test/realms/moh_applications/clients/ivf-clinic-portal/outputs.tf
@@ -1,0 +1,6 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}
+output "ROLES" {
+  value = module.client-roles.ROLES
+}

--- a/keycloak-test/realms/moh_applications/clients/ivf-clinic-portal/variables.tf
+++ b/keycloak-test/realms/moh_applications/clients/ivf-clinic-portal/variables.tf
@@ -1,0 +1,3 @@
+variable "browser_idp_restriction_flow" {}
+variable "LICENCE-STATUS" {}
+

--- a/keycloak-test/realms/moh_applications/clients/ivf-clinic-portal/versions.tf
+++ b/keycloak-test/realms/moh_applications/clients/ivf-clinic-portal/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.9.1"
+    }
+  }
+}

--- a/keycloak-test/realms/moh_applications/clients/user-management-service/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management-service/main.tf
@@ -130,6 +130,9 @@ module "client-roles" {
     "view-client-icy" = {
       "name" = "view-client-icy"
     },
+    "view-client-ivf-clinic-portal" = {
+      "name" = "view-client-ivf-clinic-portal"
+    },
     "view-client-ivf-portal" = {
       "name" = "view-client-ivf-portal"
     },

--- a/keycloak-test/realms/moh_applications/clients/user-management/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/user-management/main.tf
@@ -102,6 +102,7 @@ module "scope-mappings" {
     "USER-MANAGEMENT-SERVICE/view-client-hsiar"                     = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hsiar"].id,
     "USER-MANAGEMENT-SERVICE/view-client-hspp"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-hspp"].id,
     "USER-MANAGEMENT-SERVICE/view-client-icy"                       = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-icy"].id,
+    "USER-MANAGEMENT-SERVICE/view-client-ivf-clinic-portal"         = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-ivf-clinic-portal"].id,
     "USER-MANAGEMENT-SERVICE/view-client-ivf-portal"                = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-ivf-portal"].id,
     "USER-MANAGEMENT-SERVICE/view-client-licence-status"            = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-licence-status"].id,
     "USER-MANAGEMENT-SERVICE/view-client-maid"                      = var.USER-MANAGEMENT-SERVICE.ROLES["view-client-maid"].id,

--- a/keycloak-test/realms/moh_applications/groups/ivf-portal-management/main.tf
+++ b/keycloak-test/realms/moh_applications/groups/ivf-portal-management/main.tf
@@ -12,6 +12,7 @@ resource "keycloak_group_roles" "GROUP_ROLES" {
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-own-groups"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-details"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["manage-user-roles"].id,
+    var.USER-MANAGEMENT-SERVICE.ROLES["view-client-ivf-clinic-portal"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-client-ivf-portal"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-clients"].id,
     var.USER-MANAGEMENT-SERVICE.ROLES["view-groups"].id,


### PR DESCRIPTION
### Changes being made

Create a new IVF-CLINIC-PORTAL client. Update IVF-PORTAL.

### Context

Finalized requirements during client meeting.

### Quality Check

- [x] Client has Name and Description defined.
- [x] Full Scope Allowed is disabled.
- [x] Direct Access Grants Enabled is disabled.
- [x] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [x] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [x] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [x] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [x] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [x] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [x] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
