### PR TITLE
TEST: Add basic scope to PRIME clients.

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/prime-application-dev/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prime-application-dev/main.tf
@@ -32,6 +32,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   default_scopes = [
     "acr",
     "address",
+    "basic",
     "email",
     "profile",
     "roles",

--- a/keycloak-test/realms/moh_applications/clients/prime-application-local/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prime-application-local/main.tf
@@ -32,6 +32,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   default_scopes = [
     "acr",
     "address",
+    "basic",
     "email",
     "profile",
     "roles",

--- a/keycloak-test/realms/moh_applications/clients/prime-application-test/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/prime-application-test/main.tf
@@ -32,6 +32,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   default_scopes = [
     "acr",
     "address",
+    "basic",
     "email",
     "profile",
     "roles",


### PR DESCRIPTION
### Changes being made

TEST: Add basic scope to PRIME clients.

### Context

Accidentally removed basic scope with recent change. Client is no longer receiving "sub" claim.

### Quality Check
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]