### PR TITLE
add basic client scope

### DIFF
--- a/keycloak-prod/realms/moh_applications/clients/alr/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/alr/main.tf
@@ -33,7 +33,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 

--- a/keycloak-prod/realms/moh_applications/clients/connect/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/connect/main.tf
@@ -56,7 +56,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 

--- a/keycloak-prod/realms/moh_applications/clients/forms/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/forms/main.tf
@@ -57,7 +57,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 

--- a/keycloak-prod/realms/moh_applications/clients/hdpbc/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/hdpbc/main.tf
@@ -45,7 +45,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 

--- a/keycloak-prod/realms/moh_applications/clients/maid/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/maid/main.tf
@@ -62,6 +62,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }

--- a/keycloak-prod/realms/moh_applications/clients/metaspace/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/metaspace/main.tf
@@ -85,7 +85,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 

--- a/keycloak-prod/realms/moh_applications/clients/panorama/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/panorama/main.tf
@@ -60,6 +60,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "profile",
     "roles",
     "web-origins",
+    "basic"
   ]
 }
 resource "keycloak_openid_user_session_note_protocol_mapper" "identity_provider" {

--- a/keycloak-prod/realms/moh_applications/clients/pho-rsc/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/pho-rsc/main.tf
@@ -74,7 +74,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   client_id = keycloak_openid_client.CLIENT.id
   default_scopes = [
     "email",
-    "profile"
+    "profile",
+    "basic"
   ]
 }
 module "scope-mappings" {

--- a/keycloak-prod/realms/moh_applications/clients/ppm-api-cgi-BC30550160/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/ppm-api-cgi-BC30550160/main.tf
@@ -36,6 +36,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id
   default_scopes = [
+    "basic"
   ]
 }
 

--- a/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/primary-care/main.tf
@@ -120,7 +120,8 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }
 

--- a/keycloak-prod/realms/moh_applications/clients/tpl/main.tf
+++ b/keycloak-prod/realms/moh_applications/clients/tpl/main.tf
@@ -59,6 +59,7 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "email",
     "profile",
     "roles",
-    "web-origins"
+    "web-origins",
+    "basic"
   ]
 }


### PR DESCRIPTION
### Changes being made

For each OIDC client in PROD that manages `keycloak_openid_client_default_scopes` resource, add `basic` scope. This is a new scope added in KC version 26. It is added by default to each OIDC client, so the terraform plan should show no changes.
https://www.keycloak.org/docs/26.2.0/upgrading/#new-default-client-scope-basic

### Context

Currently marked as "draft" PR. Changes should be implemented following the Keycloak Prod upgrade.

### Quality Check

- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. 