### PR TITLE
Add backwards compatiblity mapper "session_state" to METASPACE and HDPBC clients in TEST

### DIFF
--- a/keycloak-test/realms/moh_applications/clients/hdpbc/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hdpbc/main.tf
@@ -37,7 +37,7 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "idir_company" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
 
-resource "keycloak_generic_client_protocol_mapper" "saml_hardcode_attribute_mapper" {
+resource "keycloak_generic_client_protocol_mapper" "session_state" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
   client_id       = keycloak_openid_client.CLIENT.id
   name            = "session_state"

--- a/keycloak-test/realms/moh_applications/clients/hdpbc/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hdpbc/main.tf
@@ -37,6 +37,20 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "idir_company" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_generic_client_protocol_mapper" "saml_hardcode_attribute_mapper" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "session_state"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-session-state-mapper"
+  config = {
+    "id.token.claim":"true",
+    "lightweight.claim":"false",
+    "access.token.claim":"true",
+    "introspection.token.claim":"true",
+    "userinfo.token.claim":"true"
+  }
+}
 
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id

--- a/keycloak-test/realms/moh_applications/clients/hdpbc/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/hdpbc/main.tf
@@ -44,11 +44,11 @@ resource "keycloak_generic_client_protocol_mapper" "saml_hardcode_attribute_mapp
   protocol        = "openid-connect"
   protocol_mapper = "oidc-session-state-mapper"
   config = {
-    "id.token.claim":"true",
-    "lightweight.claim":"false",
-    "access.token.claim":"true",
-    "introspection.token.claim":"true",
-    "userinfo.token.claim":"true"
+    "id.token.claim" : "true",
+    "lightweight.claim" : "false",
+    "access.token.claim" : "true",
+    "introspection.token.claim" : "true",
+    "userinfo.token.claim" : "true"
   }
 }
 

--- a/keycloak-test/realms/moh_applications/clients/metaspace/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/metaspace/main.tf
@@ -84,11 +84,11 @@ resource "keycloak_generic_client_protocol_mapper" "saml_hardcode_attribute_mapp
   protocol        = "openid-connect"
   protocol_mapper = "oidc-session-state-mapper"
   config = {
-    "id.token.claim":"true",
-    "lightweight.claim":"false",
-    "access.token.claim":"true",
-    "introspection.token.claim":"true",
-    "userinfo.token.claim":"true"
+    "id.token.claim" : "true",
+    "lightweight.claim" : "false",
+    "access.token.claim" : "true",
+    "introspection.token.claim" : "true",
+    "userinfo.token.claim" : "true"
   }
 }
 

--- a/keycloak-test/realms/moh_applications/clients/metaspace/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/metaspace/main.tf
@@ -77,7 +77,7 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "bceid_business_legalN
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
 
-resource "keycloak_generic_client_protocol_mapper" "saml_hardcode_attribute_mapper" {
+resource "keycloak_generic_client_protocol_mapper" "session_state" {
   realm_id        = keycloak_openid_client.CLIENT.realm_id
   client_id       = keycloak_openid_client.CLIENT.id
   name            = "session_state"

--- a/keycloak-test/realms/moh_applications/clients/metaspace/main.tf
+++ b/keycloak-test/realms/moh_applications/clients/metaspace/main.tf
@@ -77,6 +77,21 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "bceid_business_legalN
   realm_id        = keycloak_openid_client.CLIENT.realm_id
 }
 
+resource "keycloak_generic_client_protocol_mapper" "saml_hardcode_attribute_mapper" {
+  realm_id        = keycloak_openid_client.CLIENT.realm_id
+  client_id       = keycloak_openid_client.CLIENT.id
+  name            = "session_state"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-session-state-mapper"
+  config = {
+    "id.token.claim":"true",
+    "lightweight.claim":"false",
+    "access.token.claim":"true",
+    "introspection.token.claim":"true",
+    "userinfo.token.claim":"true"
+  }
+}
+
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
   realm_id  = keycloak_openid_client.CLIENT.realm_id
   client_id = keycloak_openid_client.CLIENT.id


### PR DESCRIPTION
### Changes being made

Add backwards compatiblity mapper "session_state" to METASPACE and HDPBC clients in TEST.

### Context

Requested by clients for BCMOHAM-24567

### Quality Check
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]